### PR TITLE
Feat: token 생성 완료(?)

### DIFF
--- a/src/main/java/com/miracle/memberservice/dto/response/TokenDto.java
+++ b/src/main/java/com/miracle/memberservice/dto/response/TokenDto.java
@@ -1,0 +1,10 @@
+package com.miracle.memberservice.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TokenDto {
+    private String token;
+}

--- a/src/main/java/com/miracle/memberservice/util/Const.java
+++ b/src/main/java/com/miracle/memberservice/util/Const.java
@@ -16,6 +16,7 @@ public abstract class Const {
         public static final String COMPANY = "company";
         public static final String ADMIN = "admin";
         public static final String RESUME = "resume";
+        public static final String HEADER_AUTHORIZATION = "Authorization";
 
     }
 }

--- a/src/main/java/com/miracle/memberservice/util/ServiceCall.java
+++ b/src/main/java/com/miracle/memberservice/util/ServiceCall.java
@@ -3,14 +3,19 @@ package com.miracle.memberservice.util;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.miracle.memberservice.dto.response.ApiResponse;
+import com.miracle.memberservice.dto.response.TokenDto;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 
 import javax.servlet.http.HttpSession;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Function;
 
 public class ServiceCall {
@@ -27,6 +32,7 @@ public class ServiceCall {
     private static Mono<ApiResponse> addCommonHeaders(WebClient.RequestHeadersSpec<?> request, HttpSession httpSession, String serviceType) {
         String capitalizeFirstLetter = capitalizeFirstLetter(serviceType);
         MiracleTokenKey key = new MiracleTokenKey(httpSession);
+        String token = "Bearer " + createToken();
 
         return request
                 .header(Const.RequestHeader.MIRACLE, key.getHashcode())
@@ -34,6 +40,7 @@ public class ServiceCall {
                 .header(capitalizeFirstLetter + Const.RequestHeader.HEADER_ID, String.valueOf(httpSession.getAttribute(Const.RequestHeader.ID)))
                 .header(capitalizeFirstLetter + Const.RequestHeader.HEADER_EMAIL, (String) httpSession.getAttribute(Const.RequestHeader.EMAIL))
                 .header(capitalizeFirstLetter + Const.RequestHeader.HEADER_BNO, (String) httpSession.getAttribute(Const.RequestHeader.BNO))
+                .header(Const.RequestHeader.HEADER_AUTHORIZATION, token)
                 .retrieve()
                 .bodyToMono(ApiResponse.class)
                 .onErrorResume(handleError());
@@ -42,11 +49,13 @@ public class ServiceCall {
     private static Mono<ApiResponse> anotherHeaders(WebClient.RequestHeadersSpec<?> request, HttpSession httpSession, String serviceType, String userId) {
         String capitalizeFirstLetter = capitalizeFirstLetter(serviceType);
         MiracleTokenKey key = new MiracleTokenKey(httpSession);
+        String token = "Bearer " + createToken();
 
         return request
                 .header(Const.RequestHeader.MIRACLE, key.getHashcode())
                 .header(Const.RequestHeader.SESSION_ID, key.getSessionId())
                 .header(capitalizeFirstLetter + Const.RequestHeader.HEADER_ID, userId)
+                .header(capitalizeFirstLetter + Const.RequestHeader.HEADER_AUTHORIZATION, token)
                 .retrieve()
                 .bodyToMono(ApiResponse.class)
                 .onErrorResume(handleError());
@@ -87,7 +96,7 @@ public class ServiceCall {
                 .uri(uriBuilder -> uriBuilder.path(VERSION + url).build()).bodyValue(dto), httpSession, serviceType).block();
     }
 
-    public static ApiResponse putParam(HttpSession httpSession, String serviceType, String url, String name, String value){
+    public static ApiResponse putParam(HttpSession httpSession, String serviceType, String url, String name, String value) {
         return addCommonHeaders(createWebClientBuilder(serviceType).build().put()
                 .uri(uriBuilder -> uriBuilder.path(VERSION + url).queryParam(name, value).build()), httpSession, serviceType).block();
     }
@@ -170,7 +179,8 @@ public class ServiceCall {
     private static String port(String memberType) {
         switch (memberType) {
             case Const.RequestHeader.USER:
-                return "3.36.113.249:60001";
+                /*return "3.36.113.249:60001";*/
+                return "localhost:60001";
             case Const.RequestHeader.COMPANY:
                 return "13.125.211.61:60002";
             case Const.RequestHeader.ADMIN:
@@ -198,5 +208,20 @@ public class ServiceCall {
             }
             return Mono.just(apiResponse);
         };
+    }
+
+    private static String createToken() {
+        RestTemplate restTemplate = new RestTemplate();
+
+        Map<String, Boolean> map = new HashMap<>();
+        map.put("gateway", true);
+        ResponseEntity<String> stringResponseEntity = restTemplate.postForEntity("http://13.125.220.223:60200/v1/jwt/create", map, String.class);
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            TokenDto tokenDto = objectMapper.readValue(stringResponseEntity.getBody(), TokenDto.class);
+            return tokenDto.getToken();
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
로직: ServiceCall 에서 RestTemplate으로 구현했는데 gateway: true를 담아서 alert-service에서 토큰을 받아와서 WebClient헤더에 넣어 주는데 이게 각 service에서 ServiceCall method를 부를 때마다 새로운 토큰을 받아서 서비스한테 보냄.