### PR TITLE
Fix : 기업 회원 프론트 리팩토링

### DIFF
--- a/src/main/resources/static/css/templatemo-pod-talk.css
+++ b/src/main/resources/static/css/templatemo-pod-talk.css
@@ -929,6 +929,7 @@ h6.my-2 {
 }
 
 
+
 /*---------------------------------------
   PROIFLE BLOCK               
 -----------------------------------------*/
@@ -1546,7 +1547,7 @@ h6.my-2 {
     flex-direction: column;
   }
 
-  .custom-block .custom-block-top small:last-child {
+  .custom-block .custom-block-top small {
     margin-top: 10px;
     margin-bottom: 10px;
   }
@@ -1565,7 +1566,10 @@ h6.my-2 {
     padding: 30px;
   }
 
-
+  .badge-wrap {
+    display: flex;
+    flex-wrap: nowrap;
+  }
 
 }
 

--- a/src/main/resources/templates/company/company-info.html
+++ b/src/main/resources/templates/company/company-info.html
@@ -33,7 +33,7 @@
 
                         <div class="row justify-content-center">
                             <div class="row ">
-                                <div class="col-lg-4 col-12">
+                                <div class="col-lg-4 col-12 my-3">
                                     <div class="custom-block-icon-wrap">
                                         <div class="custom-block-image-wrap custom-block-image-detail-page">
                                             <img th:src="'https://miracle-job-a.s3.ap-northeast-2.amazonaws.com/company/'+${info.bno}" class="custom-block-image img-fluid" alt="">

--- a/src/main/resources/templates/company/faq.html
+++ b/src/main/resources/templates/company/faq.html
@@ -16,6 +16,12 @@
 
             var question = document.getElementById('question').value;
             var answer = document.getElementById('answer').value;
+            var faqs = document.getElementsByClassName('custom-block').length;
+
+            if (faqs >= 10) {
+                alert('FAQ는 최대 10개까지만 등록 가능합니다.');
+                return false;
+            }
 
             if (question.includes('<') || question.includes('>')) {
                 alert('질문에 >, < 특수기호는 입력할 수 없습니다.');
@@ -37,90 +43,69 @@
 
         <section class="latest-podcast-section" id="section_2">
             <div class="container">
-                <div class="row justify-content-center">
-
-                    <div class="col-lg-10 col-12">
-                        <div class="section-title-wrap mb-5">
-                            <h4 class="section-title">FAQ 목록</h4>
-                        </div>
-                        <form action="/v1/company/faq/add" method="get" onsubmit="return validateForm()">
-
-                        <div class="row justify-content-center">
-                            <div class="card bg-outline-light bg-transparent text-dark shadow-lg col-12 post-form">
-                                <div class="card p-2 col-11 mt-5 align-self-center text-center">
-                                    <h6 class="text-danger">Faq 추가 시 하단으로 이동 / 삭제하려면 X버튼을 눌러주세요.</h6>
-                                </div>
-
-                                <div class="card p-4 col-11 mt-2 align-self-center post-form " th:each="faq, faqStat : ${faqList}">
-                                    <div class="col-12 mt-2 align-self-center">
-                                        <div class="d-flex justify-content-between ">
-                                            <div class="col-11 mb-2">
-                                                <button type="button" class="btn btn-outline-danger btn-primary" disabled>질문</button>
-                                            </div>
-                                            <div class="justify-content-end">
-                                                <a th:href="@{/v1/company/faq/delete/{id}(id=${faq.id})}" class="btn-secondary">
-                                                    <button type="button">X</button>
-                                                </a>
-                                            </div>
-                                        </div>
-
-                                        <input type="text" readonly id="question1"
-                                               class="form-control-plaintext" th:value="${faq.question}" />
-                                    </div>
-
-                                    <div class="col-12 mt-3 align-self-center">
-                                        <div class="mb-2">
-                                            <button type="button" class="btn btn-outline-danger" disabled>답</button>
-                                        </div>
-                                        <textarea readonly class="form-control-plaintext" rows="2"
-                                                  id="answer1" th:text="${faq.answer}" style="resize: none;"></textarea>
-                                        <input type="hidden" name="faqId" th:value="${faq.id}" />
-                                    </div>
-                                </div>
-
-                                <!-- 구분선 -->
-                                <div class="col-10 m-5 align-self-center">
-                                    <hr>
-                                </div>
-
-                                <!-- 질문 생성 -->
-                                <div class="card p-4 col-11 align-self-center post-form ">
-                                    <div class="col-12 mt-2 align-self-center">
-                                        <div class="mb-2">
-                                            <label for="question">질문</label>
-                                        </div>
-                                        <div class="form-floating">
-                                        <input type="text" name="question" id="question"
-                                               class="form-control"/>
-                                        <label for="floatingInput">질문 내용 입력</label>
-                                    </div>
-                                    </div>
-
-                                    <div class="col-12 mt-3 align-self-center">
-                                        <div class="mb-2">
-                                            <label for="answer">답</label>
-                                        </div>
-                                        <div class="form-floating">
-                                        <input type="text" class="form-control" id="answer" name="answer"></input>
-                                        <label for="floatingInput">답변 내용 입력</label>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <input type="hidden" name="companyId" th:value="${session.id}" />
-
-                                <div class="col-10 mt-4 align-self-center text-center">
-                                    <h5 class="text-secondary">자주하는 질문은 최대 10개 가지 등록가능합니다.</h5>
-                                </div>
-                                <div class="col-8 mb-5 align-self-center">
-                                    <button type="submit" class="form-control">등록하기</button>
-                                </div>
-
-                            </div>
-                        </div>
-                        </form>
-                    </div>
+                <div class="section-title-wrap col-8 mb-3 mx-auto">
+                    <h4 class="section-title">FAQ 관리</h4>
                 </div>
+
+                    <div class="row justify-content-center col-md-9 col-12 mb-5 mx-auto">
+                        <div class="card bg-outline-light bg-transparent text-dark shadow-lg col-md-12 col-12 mt-1 mb-5">
+                            <form action="/v1/company/faq/add" method="get" class="row col-md-11 col-12 mx-auto" onsubmit="return validateForm()">
+                                <div class="card-body align-self-center mx-auto">
+                                    <div class="col-12 mt-3 mx-auto">
+                                        <div class="d-flex justify-content-between align-items-center">
+                                            <h6 class="my-3">
+                                                질문
+                                                <small class="text-danger" style="font-size: small">
+                                                    (문항은 최대 10개까지 등록 가능합니다.)
+                                                </small>
+                                            </h6>
+                                            <button class="custom-border-option-btn" type="submit">등록</button>
+                                        </div>
+                                        <input type="text" name="question" id="question" placeholder="질문내용 입력" class="form-control" required/>
+
+                                        <h6 class="mt-4 mb-3">답</h6>
+                                        <textarea type="text" class="form-control" rows="2" id="answer"
+                                                  name="answer" required></textarea>
+
+                                        <input type="hidden" name="companyId" th:value="${session.id}" />
+                                    </div>
+
+                                    <div class="col-12 mt-5 mx-auto">
+                                        <hr>
+                                    </div>
+
+                                    <div class="col-12 my-5 mx-auto">
+                                        <div th:if="${#lists.isEmpty(faqList)}" class="text-center">
+                                            <h6>등록된 내용이 없습니다. 위에 질문과 답을 등록해주세요.</h6>
+                                        </div>
+
+                                        <div class="row custom-block d-flex my-3" th:each="faq, faqStat : ${faqList}">
+                                            <div class="col-md-11 col-10 pt-2">
+                                                <span class="badge bg-dark my-2">질문</span>
+                                                <input type="text" readonly id="question1"
+                                                       class="form-control-plaintext mb-2" th:value="${faq.question}" />
+                                                <span class="badge bg-dark my-2">답변</span>
+                                                <textarea readonly class="form-control-plaintext autoresize"
+                                                          id="answer1" th:text="${faq.answer}" style="resize: none;"></textarea>
+                                                <input type="hidden" name="faqId" th:value="${faq.id}" />
+                                            </div>
+                                            <div class="col-md-1 col-1 m-auto">
+                                                <a th:href="@{/v1/company/faq/delete/{id}(id=${faq.id})}" >
+                                                    <button type="button" class="btn btn-outline-secondary">
+                                                        <span class="d-none d-sm-inline bi-trash"></span>
+                                                        <span class="d-inline d-sm-none bi-trash"></span>
+                                                    </button></a>
+                                            </div>
+                                        </div>
+
+                                    </div>
+
+
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+
             </div>
         </section>
 

--- a/src/main/resources/templates/company/modify-form.html
+++ b/src/main/resources/templates/company/modify-form.html
@@ -222,7 +222,7 @@
                         <form action="/v1/company/info/update" method="post" role="form" enctype="multipart/form-data">
                         <div class="row justify-content-center">
                             <div class="row ">
-                                <div class="col-lg-4 col-12">
+                                <div class="col-lg-4 col-12 my-3">
                                     <div class="custom-block-icon-wrap">
                                         <div class="custom-block-image-wrap custom-block-image-detail-page" id="originalPhoto">
                                             <img th:src="'https://miracle-job-a.s3.ap-northeast-2.amazonaws.com/company/'+${info.bno}" class="custom-block-image img-fluid" alt="">
@@ -317,12 +317,12 @@
 
                                         <div class="row col-12 my-5">
                                             <div class="col-4">
-                                                <button type="button" class="form-control" id="back" onclick="goBack()">돌아가기</button>
+                                                <button type="button" class="form-control rounded-pill" id="back" onclick="goBack()">돌아가기</button>
 
                                             </div>
                                             <div class="col-4">
-                                                <button type="button" class="form-control" id="signoutBtn"
-                                                        onclick="signoutCompany()">회원 탈퇴하기
+                                                <button type="button" class="form-control rounded-pill" id="signoutBtn"
+                                                        onclick="signoutCompany()">회원탈퇴
                                                 </button>
                                             </div>
                                             <div class="col-4">

--- a/src/main/resources/templates/company/mz-post.html
+++ b/src/main/resources/templates/company/mz-post.html
@@ -208,255 +208,209 @@
 
         <section class="latest-podcast-section" id="section_2">
             <div class="container">
-                <div class="section-title-wrap mb-5">
-                    <h4 class="section-title">공고 등록</h4>
+                <div class="section-title-wrap col-8 mb-3 mx-auto">
+                    <h4 class="section-title">MZ공고 등록</h4>
                 </div>
-                <div class="row justify-content-center">
-                    <div class="card bg-outline-light text-dark ">
-                        <form action="/v1/company/post/create" method="post" class="post-form" role="form" id="dateForm"
+                <div class="row justify-content-center col-md-9 col-12 mb-5 mx-auto">
+                    <div class="card bg-outline-light text-dark shadow-lg col-md-12 col-12 mt-1 mb-5">
+                        <form action="/v1/company/post/create" method="post" class="row col-md-11 col-12 mx-auto" role="form" id="dateForm"
                               onsubmit="return validateForm()">
-                            <div class="card-body">
+                            <div class="card-body align-self-center mx-auto">
 
-                                <div class="col-8">
-                                    <div class="mb-1">
-                                        <label for="title">공고 제목</label><label class="text-danger"> *필수</label>
-                                    </div>
-                                    <input type="text" name="title" id="title"
-                                           class="form-control" placeholder="공고제목" required=""/>
+                                <div class="col-12 mx-auto my-3">
+                                    <h6>공고 제목 <small class="text-danger" style="font-size: small"> *필수</small> </h6>
+                                    <input type="text" name="title" id="title" class="form-control" required />
                                 </div>
-                                <div class="row">
-                                    <div class="col-4 mt-2 ">
-                                        <div class="mb-1">
-                                            <label for="endDate">마감일</label><label class="text-danger"> *필수(분(minute)은 등록되지 않습니다. 예)12:06:12->12:00:00)</label>
-                                        </div>
-                                        <input type="datetime-local" name="endDate" id="endDate"
-                                               class="form-control" placeholder="마감일" required=""/>
+
+                                <div class="card mt-3 col-12 mx-auto">
+                                    <hr>
+                                    <div class="mb-1">
+                                        <h6>스택<small><span class="text-danger" style="font-size: small"> *한 개이상 필수 입니다.</span></small></h6>
                                     </div>
-                                    <div class="col-4 mt-2">
-                                        <div class="mb-1">
-                                            <label for="career">경력</label><label class="text-danger"> *필수</label>
+                                    <div class="custom-card-border row my-1 py-2 px-1"
+                                         data-bs-toggle="tooltip" data-bs-html="true"
+                                         title="우리 회사에서 사용하는 기술스택을 선택해 적절한 인재를 찾으세요.">
+                                        <div class="row mx-auto">
+                                            <div th:each="stack : ${stacks}" class="editJobs form-check col-md-3 col-6">
+                                                <input class="form-check-input" type="checkbox" id="stack" name="stackIdSet"
+                                                       th:value="${stack.id}"
+                                                       th:checked="${stackIdSet != null and stackIdSet.contains(stack)}"/>
+                                                <label class="form-check-label" th:text="${stack.name}"></label>
+                                            </div>
                                         </div>
+                                    </div>
+                                </div>
+
+                                <div class="row col-12 mx-auto my-4">
+                                    <hr class="mb-1">
+                                    <div class="col-4 mt-2">
+                                        <h6><small>경력<span class="text-danger" style="font-size: small"> *필수</span></small></h6>
                                         <input type="number" name="career" id="career" class="form-control"
                                                placeholder="경력(년)" required=""
                                                oninput="this.value = this.value.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1');"/>
                                     </div>
+                                    <div class="col-8 mt-2">
+                                        <h6><small>마감일<span class="text-danger" style="font-size: small"> *필수(분(minute)은 등록되지 않습니다. 예)12:06:12->12:00:00)</span></small></h6>
+                                        <input type="datetime-local" name="endDate" id="endDate"
+                                               class="form-control" placeholder="마감일" required=""/>
+                                    </div>
                                 </div>
 
 
-                                <div class="col-8 mt-2">
+                                <div class="card mt-3 col-12 mx-auto">
+                                    <hr>
                                     <div class="mb-1">
-                                        <label for="jobId">직무</label><label class="text-danger"> *필수</label>
+                                        <h6>직무<small><span class="text-danger" style="font-size: small"> *필수</span></small></h6>
                                     </div>
-                                    <div th:each="job, jobStat : ${jobs}" style="display: inline-block;">
-                                        <input class="form-check-input" type="radio" id="job" name="jobIdSet"
-                                               th:value="${job.id}" required/>
-                                        <label class="form-check-label" th:text="${job.name}"></label>
+                                    <div class="custom-card-border row my-1 py-2 px-1 ">
+                                        <div class="row mx-auto">
+                                            <div th:each="job, jobStat : ${jobs}" class="editJobs form-check col-md-4 col-6">
+                                                <input class="form-check-input" type="radio" id="job"
+                                                       name="jobIdSet" th:value="${job.id}" required />
+                                                <label class="form-check-label" th:text="${job.name}"></label>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
 
-
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="stackId">요구스택</label><label class="text-danger"> *하나 이상 필수</label>
-                                    </div>
-                                    <div th:each="stack, stackStat : ${stacks}" style="display: inline-block;">
-                                        <input class="form-check-input" type="checkbox" id="stack" name="stackIdSet"
-                                               th:value="${stack.id}"/>
-                                        <label class="form-check-label" th:text="${stack.name}"></label>
-                                    </div>
-
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>개발 툴<small><span class="text-danger" style="font-size: small"> * 필수</span></small></h6>
+                                    <input type="text" name="tool" id="tool" class="form-control" required>
                                 </div>
 
-
-                                <div class="col-8 mt-4">
-                                    <h4 class="mb-2">회사 정보</h4><label class="text-warning">*회사 정보 수정 필요 시 기업페이지에서 해주세요</label>
-                                    <!--
-                                     회사명 : name
-                                     대표자 : ceoName
-                                     재직인원 : employeeNum
-                                     근무주소(디폴트 회사 주소) : address
-                                     사진 : photo
-                                     -->
-                                    <div class="row">
-                                        <div class="col-4 mt-2">
-                                            <div class="mb-1">
-                                                <label for="name">회사명</label>
-                                            </div>
-                                            <input type="text" name="name" id="name" th:value="${info.name}"
-                                                   class="form-control" placeholder="회사명" disabled/>
-                                        </div>
-                                        <div class="col-4 mt-2">
-                                            <div class="mb-1">
-                                                <label for="ceoName">대표자명</label>
-                                            </div>
-                                            <input type="text" name="ceoName" id="ceoName" th:value="${info.ceoName}"
-                                                   class="form-control" placeholder="대표자명" disabled/>
-                                        </div>
-                                        <div class="col-4 mt-2">
-                                            <div class="mb-1">
-                                                <label for="employeeNum">재직인원</label>
-                                            </div>
-                                            <input type="number" name="employeeNum" id="employeeNum"
-                                                   th:value="${info.employeeNum}"
-                                                   class="form-control" placeholder="재직인원" disabled
-                                                   oninput="this.value = this.value.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1');"/>
-                                        </div>
-
-                                        <div class="col-lg-4 col-12">
-                                            <div class="custom-block-icon-wrap">
-                                                <div class="custom-block-image-wrap custom-block-image-detail-page">
-                                                    <img th:src="${info.photo}" class="custom-block-image img-fluid" alt="">
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>주요업무 <small class="text-danger" style="font-size: small"> *필수</small> </h6>
+                                    <textarea class="form-control autoresize" rows="5" id="mainTask" name="mainTask" required></textarea>
                                 </div>
-                                <!--
-                                    기업소개(기업테이블) : introduction
-                                    주요업무 : mainTask
-                                    근무조건 : workCondition
-                                    자격요건 : qualification
-                                    개발 툴 : tool
-                                    복지 및 혜택 : benefit
-                                    우대 기술사항 : special_skill
-                                    채용절차 : process
-                                    유의사항 : notice
-                                    근무주소 : workAddress
-                                    테스트링크 : questionGit
-                                -->
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="introduction">기업소개</label>
+
+                                <div class="col-12 mx-auto my-3">
+                                    <hr class="my-2">
+                                    <h6>근무조건 <small class="text-danger" style="font-size: small"> *필수</small> </h6>
+                                    <textarea class="form-control autoresize" rows="5" id="workCondition" name="workCondition" required></textarea>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>자격요건</h6>
+                                    <textarea class="form-control autoresize" rows="5" id="qualification" name="qualification"></textarea>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>우대 기술사항</h6>
+                                    <textarea class="form-control autoresize" rows="5" id="special_skill" name="specialSkill"></textarea>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>복지 및 혜택</h6>
+                                    <textarea class="form-control autoresize" rows="5" id="benefit" name="benefit"></textarea>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>채용절차</h6>
+                                    <textarea class="form-control autoresize mb-4" rows="5" id="process" name="process" required></textarea>
+                                    <hr>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>회사정보<small class="text-secondary" style="font-size: small"> (정보수정 필요 시 기업 페이지에서 변경가능)</small></h6>
+                                    <div class="custom-block-icon-wrap my-2">
+                                        <img class="mx-auto img-fluid rounded-1 d-block" th:src="${info.photo}" name="photo" alt="company-img"/>
                                     </div>
-                                    <textarea class="form-control" rows="3" id="introduction" name="introduction"
+                                    <h6 class="my-2"><small>회사명</small></h6>
+                                    <input type="text" readonly name="name" id="name" th:value="${info.name}"
+                                           class="form-control-plaintext" placeholder="회사명" disabled/>
+
+                                    <h6 class="my-2"><small>대표자</small></h6>
+                                    <input type="text" readonly name="ceoName" id="ceoName" th:value="${info.ceoName}"
+                                           class="form-control-plaintext" placeholder="대표자명" disabled/>
+
+                                    <h6 class="my-2"><small>재직인원</small></h6>
+                                    <input type="number" readonly name="employeeNum" id="employeeNum"
+                                           th:value="${info.employeeNum}"
+                                           class="form-control-plaintext" placeholder="재직인원" disabled
+                                           oninput="this.value = this.value.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1');"/>
+
+                                    <h6 class="my-4">기업소개</h6>
+                                    <textarea class="form-control autoresize" rows="5" id="introduction" name="introduction"
                                               th:value="${info.introduction}" th:text="${info.introduction}"
                                               readonly></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="mainTask">주요업무</label><label class="text-danger"> *필수</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="mainTask" name="mainTask"
-                                              required></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="workCondition">근무조건</label><label class="text-danger"> *필수</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="workCondition"
-                                              name="workCondition" required></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="qualification">자격요건</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="qualification"
-                                              name="qualification"></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="tool">개발 툴</label><label class="text-danger"> *필수</label>
-                                        <input type="text" name="tool" id="tool"
-                                               class="form-control" required="">
-                                    </div>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="benefit">복지 및 혜택</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="benefit" name="benefit"></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="special_skill">우대 기술사항</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="special_skill"
-                                              name="specialSkill"></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="process">채용절차</label><label class="text-danger"> *필수</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="process" name="process"
-                                              required></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="notice">유의사항</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="notice" name="notice"></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="address">근무주소(세부주소 포함)</label><label class="text-danger">
-                                        *필수</label>
-                                    </div>
-                                    <input type="text" name="workAddress" id="address"
-                                           class="form-control mb-2" placeholder="근무주소" th:value="${info.address}"
-                                           required/>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="form-floating">
-                                        <button type="button" class="custom-btn" id="addressInputBtn">주소변경</button>
+
+                                    <h6 class="my-4">근무지 주소
+                                        <small class="text-secondary" style="font-size: small">(세부주소 포함)</small>
+                                        <small class="text-danger" style="font-size: small">  *필수</small>
+                                    </h6>
+                                    <div class="input-group mb-4">
+                                        <input type="text" name="workAddress" id="address"
+                                               class="form-control" placeholder="근무주소" th:value="${info.address}" required/>
+                                        <button type="button" class="custom-border-option-btn" id="addressInputBtn">주소변경</button>
                                     </div>
                                 </div>
 
-                                <h5 class="mb-4 mt-4">MZ 질문</h5>
+                                <div class="col-12 mx-auto my-4">
+                                    <hr>
+                                    <h6>유의사항</h6>
+                                    <textarea class="form-control autoresize mb-4" rows="5" id="notice" name="notice"></textarea>
+                                    <hr>
+                                </div>
 
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="testStartDate">테스트 시작일</label><label class="text-danger">
-                                        *필수(분(minute)은 등록되지 않습니다. 예)12:06:12->12:00:00)</label>
-                                    </div>
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>MZ 질문</h6>
+                                    <h6 class="my-3"><small>테스트 시작일</small>
+                                        <span class="text-danger" style="font-size: small">
+                                            *필수(분(minute)은 등록되지 않습니다. 예)12:06:12->12:00:00)
+                                        </span>
+                                    </h6>
                                     <input type="datetime-local" name="testStartDate" id="testStartDate"
-                                           class="form-control" placeholder="test_start" required=""/>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="testEndDate">테스트 종료일</label><label class="text-danger"> *필수(분(minute)은 등록되지 않습니다. 예)12:06:12->12:00:00)</label>
-                                    </div>
+                                           class="form-control mb-2" placeholder="test_start" required=""/>
+                                    <h6 class="my-3"><small>테스트 종료일</small>
+                                        <span class="text-danger" style="font-size: small">
+                                            *필수(분(minute)은 등록되지 않습니다. 예)12:06:12->12:00:00)
+                                        </span>
+                                    </h6>
                                     <input type="datetime-local" name="testEndDate" id="testEndDate"
-                                           class="form-control" placeholder="test_end" required=""/>
-                                </div>
-
-                                <!-- param 값 question 으로 동일하니 주의 ! -->
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="questionGit">테스트 링크</label><label class="text-danger"> *필수</label>
-                                    </div>
+                                           class="form-control mb-2" placeholder="test_end" required=""/>
+                                    <h6 class="my-3"><small>테스트 링크</small>
+                                        <span class="text-danger" style="font-size: small">
+                                            *필수
+                                        </span>
+                                    </h6>
                                     <input type="url" name="questionList" id="questionGit"
-                                           class="form-control" placeholder="git 주소를 업로드 해주세요." required=""/>
+                                           class="form-control mb-2" placeholder="git 주소를 업로드 해주세요." required=""/>
                                 </div>
 
 
                                 <!-- Company_FAQ 의 질문(question) 컬럼명이 겹침 주의 ! -->
-                                <h5 class="mb-4 mt-4">자주하는 질문</h5><label class="text-warning">*FAQ 수정 필요 시 상단 faq바를 이용해주세요.</label>
-                                <div class="accordion" th:each="faq, faqStat : ${info.faqList}" id="accordionExample">
-                                    <div class="accordion-item mb-3">
-                                        <h2 class="accordion-header" th:id="'heading' + ${faqStat.index}">
-                                            <button class="accordion-button collapsed rounded" type="button"
-                                                    data-bs-toggle="collapse"
-                                                    th:data-bs-target="'#collapse' + ${faqStat.index}"
-                                                    aria-expanded="false"
-                                                    th:aria-controls="'collapse' + ${faqStat.index}">
-                                                <strong th:text="${faq.question}"></strong>
-                                            </button>
-                                        </h2>
-                                        <div th:id="'collapse' + ${faqStat.index}" class="accordion-collapse collapse"
-                                             th:aria-labelledby="'heading' + ${faqStat.index}">
-                                            <div class="accordion-body">
-                                                <strong th:text="${faq.answer}"></strong>
+                                <div class="col-12 mx-auto my-4">
+                                    <hr>
+                                    <h6 class="mt-2">자주하는 질문
+                                        <small class="text-secondary" style="font-size: small">
+                                            FAQ 수정 필요 시 상단 faq바를 이용해주세요.
+                                        </small>
+                                    </h6>
+                                    <div class="accordion" th:each="faq, faqStat : ${info.faqList}" id="accordionExample">
+                                        <div class="accordion-item mb-3">
+                                            <h2 class="accordion-header" th:id="'heading' + ${faqStat.index}">
+                                                <button class="accordion-button collapsed rounded" type="button"
+                                                        data-bs-toggle="collapse"
+                                                        th:data-bs-target="'#collapse' + ${faqStat.index}"
+                                                        aria-expanded="false"
+                                                        th:aria-controls="'collapse' + ${faqStat.index}">
+                                                    <strong th:text="${faq.question}"></strong>
+                                                </button>
+                                            </h2>
+                                            <div th:id="'collapse' + ${faqStat.index}" class="accordion-collapse collapse"
+                                                 th:aria-labelledby="'heading' + ${faqStat.index}">
+                                                <div class="accordion-body">
+                                                    <strong th:text="${faq.answer}"></strong>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
 
-                                <div class="col-6 pt-4 m-auto">
-                                    <input type="hidden" name="postType" value="MZ"/>
-                                    <button type="submit" class="form-control">등록하기</button>
+                                <input type="hidden" name="postType" value="MZ"/>
+                                <div class="col-12 my-3 pt-4 d-flex justify-content-center ">
+                                    <button type="submit" class="custom-btn">등록하기</button>
                                 </div>
-
 
                             </div>
                         </form>

--- a/src/main/resources/templates/company/mz-post.html
+++ b/src/main/resources/templates/company/mz-post.html
@@ -231,7 +231,7 @@
                                          data-bs-toggle="tooltip" data-bs-html="true"
                                          title="우리 회사에서 사용하는 기술스택을 선택해 적절한 인재를 찾으세요.">
                                         <div class="row mx-auto">
-                                            <div th:each="stack : ${stacks}" class="editJobs form-check col-md-3 col-6">
+                                            <div th:each="stack : ${stacks}" class="editStacks form-check col-md-3 col-6">
                                                 <input class="form-check-input" type="checkbox" id="stack" name="stackIdSet"
                                                        th:value="${stack.id}"
                                                        th:checked="${stackIdSet != null and stackIdSet.contains(stack)}"/>
@@ -356,14 +356,14 @@
                                     <h6>MZ 질문</h6>
                                     <h6 class="my-3"><small>테스트 시작일</small>
                                         <span class="text-danger" style="font-size: small">
-                                            *필수(분(minute)은 등록되지 않습니다. 예)12:06:12->12:00:00)
+                                            *필수(분(minute)은 등록되지 않습니다. 예)12:06->12:00) / 시작일은 공고 마감일 이후 시점 등록가능
                                         </span>
                                     </h6>
                                     <input type="datetime-local" name="testStartDate" id="testStartDate"
                                            class="form-control mb-2" placeholder="test_start" required=""/>
                                     <h6 class="my-3"><small>테스트 종료일</small>
                                         <span class="text-danger" style="font-size: small">
-                                            *필수(분(minute)은 등록되지 않습니다. 예)12:06:12->12:00:00)
+                                            *필수(분(minute)은 등록되지 않습니다. 예)12:06->12:00)
                                         </span>
                                     </h6>
                                     <input type="datetime-local" name="testEndDate" id="testEndDate"

--- a/src/main/resources/templates/company/mzPost-detail.html
+++ b/src/main/resources/templates/company/mzPost-detail.html
@@ -37,12 +37,17 @@
             $('#closedBtn').css('display', 'none');
             $('#removeBtn').css('display', 'none');
             $('#editBtn').css('display', 'none');
+            $('#goBackListBtn').css('display','none');
             $('#cancelBtn').css('display', 'block');
         }
 
         function cancelEditing() {
             var postId = [[${postId}]];
-            window.location.href = '/v1/company/post/detail?id=' + postId;
+            window.location.href = '/v1/company/post/detail?id=' + postId + '&postType=MZ';
+        }
+
+        function goBackList(){
+            window.location.href = '/v1/company/post/list/1';
         }
 
         /* 주소 변경하기 */
@@ -261,278 +266,238 @@
 
         <section class="latest-podcast-section" id="section_2">
             <div class="container">
-                <div class="section-title-wrap mb-5">
-                    <h4 class="section-title">공고 상세조회</h4>
+                <div class="section-title-wrap col-8 mb-3 mx-auto">
+                    <h4 class="section-title">MZ공고 상세조회</h4>
                 </div>
-                <div class="row justify-content-center">
-                    <div class="card bg-outline-light text-dark ">
-                        <form th:action="@{/v1/company/post/update}" method="post" class="post-form" role="form">
-                            <div class="card-body">
+                <div class="row justify-content-center col-md-9 col-12 mb-5 mx-auto">
+                    <div class="card bg-outline-light text-dark shadow-lg col-md-12 col-12 mt-1 mb-5">
+                        <form th:action="@{/v1/company/post/update}" method="post" class="row col-md-11 col-12 mx-auto" role="form">
+                            <div class="card-body align-self-center mx-auto">
 
-                                <div class="col-8">
-                                    <div class="mb-1">
-                                        <label for="title">공고 제목</label><label class="text-danger"> *필수</label>
-                                    </div>
+                                <div class="col-12 mx-auto my-3">
+                                    <h6>공고 제목 <small class="text-danger" style="font-size: small"> *필수</small> </h6>
                                     <input type="text" name="title" id="title"
-                                           class="form-control" placeholder="공고제목" th:value="${detail.title}" readonly required/>
-                                </div>
-                                <div class="row">
-                                    <div class="col-4 mt-2 ">
-                                        <div class="mb-1">
-                                            <label for="endDate">마감일</label><label class="text-danger"> *필수(분(minute)은 등록되지 않습니다. 예)12:06:12->12:00:00)</label>
-                                        </div>
-                                        <input type="datetime-local" name="endDate" id="endDate"
-                                               class="form-control" placeholder="마감일" th:value="${detail.endDate}"
-                                               readonly required/>
-                                    </div>
-                                    <div class="col-4 mt-2">
-                                        <div class="mb-1">
-                                            <label for="career">경력</label><label class="text-danger"> *필수</label>
-                                        </div>
-                                        <input type="number" name="career" id="career" class="form-control"
-                                               placeholder="경력(년)" th:value="${detail.career}" readonly required
-                                               oninput="this.value = this.value.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1');"/>
-                                    </div>
+                                           class="form-control" th:value="${detail.title}" readonly required />
                                 </div>
 
-
-                                <div class="col-8 mt-2">
+                                <div class="card mt-3 col-12 mx-auto">
+                                    <hr>
                                     <div class="mb-1">
-                                        <label for="jobId">직무</label><label class="text-danger"> *필수</label>
+                                        <h6>스택<small><span class="text-danger" style="font-size: small"> *한 개이상 필수 입니다.</span></small></h6>
                                     </div>
-                                    <div th:each="job : ${totalJobs}" class="editJobs" style="display: none;">
-                                        <input class="form-check-input" type="radio" th:id="'job'+${job.id}"
-                                               name="jobIdSet" required
-                                               th:value="${job.id}" th:checked="${jobs != null and jobs.contains(job)}"/>
-                                        <label class="form-check-label" th:text="${job.name}"></label>
-                                        <br/>
-                                    </div>
-                                    <div th:if="${jobs != null}">
-                                        <div th:each="job : ${jobs}" id="jobs" style="display: inline-block;">
-                                            <label class="form-check-label bi-person-workspace"
-                                                   th:text="'  '+${job.name}"></label>
-                                            <br/>
-                                        </div>
-                                    </div>
-
-                                </div>
-
-
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="stackId">요구스택</label><label class="text-danger"> *하나 이상 필수</label>
-                                    </div>
-                                    <div th:each="stack : ${totalStacks}" class="editStacks" style="display: none;">
-                                        <input class="form-check-input" type="checkbox" th:id="'stack'+${stack.id}"
-                                               name="stackIdSet"
-                                               th:value="${stack.id}" th:checked="${stacks != null and stacks.contains(stack)}"/>
-                                        <label class="form-check-label" th:text="${stack.name}"></label>
-                                        <br/>
-                                    </div>
-                                    <div th:if="${stacks != null}">
-                                        <div th:each="stack : ${stacks}" id="stacks" style="display: inline-block;">
-                                            <label class="form-check-label bi-view-stacked"
-                                                   th:text="'  '+${stack.name}"></label>
-                                            <br/>
-                                        </div>
-                                    </div>
-
-                                </div>
-
-
-                                <div class="col-8 mt-4">
-                                    <h4 class="mb-2">회사 정보</h4><label class="text-warning">*회사 정보 수정 필요 시 기업페이지에서 해주세요</label>
-                                    <!--
-                                     회사명 : name
-                                     대표자 : ceoName
-                                     재직인원 : employeeNum
-                                     근무주소(디폴트 회사 주소) : address
-                                     사진 : photo
-                                     -->
-                                    <div class="row">
-                                        <div class="col-4 mt-2">
-                                            <div class="mb-1">
-                                                <label for="name">회사명</label>
+                                    <div class="custom-card-border row my-1 py-2 px-1"
+                                         data-bs-toggle="tooltip" data-bs-html="true"
+                                         title="우리 회사에서 사용하는 기술스택을 선택해 적절한 인재를 찾으세요.">
+                                        <div class="row mx-auto">
+                                            <div th:each="stack : ${totalStacks}" class="editStacks form-check col-md-3 col-6" style="display: none;">
+                                                <input class="form-check-input" type="checkbox" th:id="'stack'+${stack.id}"
+                                                       name="stackIdSet" th:value="${stack.id}"
+                                                       th:checked="${stacks != null and stacks.contains(stack)}"/>
+                                                <label class="form-check-label" th:text="${stack.name}"></label>
                                             </div>
-                                            <input type="text" name="name" id="name" th:value="${info.name}"
-                                                   class="form-control" placeholder="회사명" disabled/>
-                                        </div>
-                                        <div class="col-4 mt-2">
-                                            <div class="mb-1">
-                                                <label for="ceoName">대표자명</label>
-                                            </div>
-                                            <input type="text" name="ceoName" id="ceoName" th:value="${info.ceoName}"
-                                                   class="form-control" placeholder="대표자명" disabled/>
-                                        </div>
-                                        <div class="col-4 mt-2">
-                                            <div class="mb-1">
-                                                <label for="employeeNum">재직인원</label>
-                                            </div>
-                                            <input type="number" name="employeeNum" id="employeeNum"
-                                                   th:value="${info.employeeNum}"
-                                                   class="form-control" placeholder="재직인원" disabled
-                                                   oninput="this.value = this.value.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1');"/>
-                                        </div>
-
-                                        <div class="col-lg-4 col-12">
-                                            <div class="custom-block-icon-wrap">
-                                                <div class="custom-block-image-wrap custom-block-image-detail-page">
-                                                    <img th:src="${info.photo}" class="custom-block-image img-fluid" alt="">
+                                            <div th:if="${stacks != null}">
+                                                <div th:each="stack : ${stacks}" id="stacks" style="display: inline-block;">
+                                                    <label class="form-check-label bi-view-stacked" th:text="'  '+${stack.name}"></label>
+                                                    <br/>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
-
                                 </div>
 
-                                <!--
-                                    기업소개(기업테이블) : introduction
-                                    주요업무 : mainTask
-                                    근무조건 : workCondition
-                                    자격요건 : qualification
-                                    개발 툴 : tool
-                                    복지 및 혜택 : benefit
-                                    우대 기술사항 : special_skill
-                                    채용절차 : process
-                                    유의사항 : notice
-
-                                -->
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="introduction">기업소개</label>
+                                <div class="row col-12 mx-auto my-4">
+                                    <hr class="mb-1">
+                                    <div class="col-4 mt-2">
+                                        <h6><small>경력<span class="text-danger" style="font-size: small"> *필수</span></small></h6>
+                                        <input type="number" name="career" id="career" class="form-control"
+                                               placeholder="경력(년)"  th:value="${detail.career}" readonly required=""
+                                               oninput="this.value = this.value.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1');"/>
                                     </div>
-                                    <textarea class="form-control" rows="3" id="introduction" name="introduction"
-                                              th:value="${info.introduction}" th:text="${info.introduction}"
-                                              readonly></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="mainTask">주요업무</label><label class="text-danger"> *필수</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="mainTask" name="mainTask"
-                                              th:text="${detail.mainTask}" readonly required></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="workCondition">근무조건</label><label class="text-danger"> *필수</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="workCondition"
-                                              name="workCondition" th:text="${detail.workCondition}"
-                                              readonly required></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="qualification">자격요건</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="qualification"
-                                              name="qualification" th:text="${detail.qualification}"
-                                              readonly></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="tool">개발 툴</label><label class="text-danger"> *필수</label>
-                                        <input type="text" name="tool" id="tool"
-                                               class="form-control" th:value="${detail.tool}" readonly required/>
-                                    </div>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="benefit">복지 및 혜택</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="benefit" name="benefit"
-                                              th:text="${detail.benefit}" readonly></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="special_skill">우대 기술사항</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="specialSkill"
-                                              name="specialSkill" th:text="${detail.specialSkill}" readonly></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="process">채용절차</label><label class="text-danger"> *필수</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="process" name="process"
-                                              th:text="${detail.process}" readonly required></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="notice">유의사항</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="notice" name="notice"
-                                              th:text="${detail.notice}" readonly></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="address">근무주소(세부주소 포함)</label><label class="text-danger"> *필수</label>
-                                    </div>
-                                    <input type="text" name="workAddress" id="address"
-                                           class="form-control mb-2" placeholder="근무주소" th:value="${detail.workAddress}"
-                                           readonly required/>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="form-floating">
-                                        <button type="button" class="custom-btn" id="addressInputBtn"
-                                                style="display: none">주소변경
-                                        </button>
+                                    <div class="col-8 mt-2">
+                                        <h6><small>마감일<span class="text-danger" style="font-size: small"> *필수(분(minute)은 등록되지 않습니다. 예)12:06:12->12:00:00)</span></small></h6>
+                                        <input type="datetime-local" name="endDate" id="endDate"
+                                               class="form-control" placeholder="마감일" th:value="${detail.endDate}"
+                                               readonly required=""/>
                                     </div>
                                 </div>
 
-                                <h5 class="mb-4 mt-4">MZ 질문</h5>
 
-                                <div class="col-8 mt-2">
+                                <div class="card mt-3 col-12 mx-auto">
+                                    <hr>
                                     <div class="mb-1">
-                                        <label for="testStartDate">테스트 시작일</label><label class="text-danger"> *필수(분(minute)은 등록되지 않습니다. 예)12:06:12->12:00:00)</label>
+                                        <h6>직무<small><span class="text-danger" style="font-size: small"> *필수</span></small></h6>
                                     </div>
-                                    <input type="datetime-local" name="testStartDate" id="testStartDate"
-                                           class="form-control" placeholder="test_start"
-                                           th:value="${detail.testStartDate}" disabled required=""/>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="testEndDate">테스트 종료일</label><label class="text-danger"> *필수(분(minute)은 등록되지 않습니다. 예)12:06:12->12:00:00)</label>
-                                    </div>
-                                    <input type="datetime-local" name="testEndDate" id="testEndDate"
-                                           class="form-control" placeholder="test_end" th:value="${detail.testEndDate}"
-                                           disabled required=""/>
-                                </div>
-
-                                <!-- param 값 question 으로 동일하니 주의 ! -->
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="questionGit">테스트 링크</label><label class="text-danger"> *필수</label>
-                                    </div>
-                                    <input type="hidden" name="idList" th:value="${detail.questionList[0].id}"/>
-                                    <input type="text" name="questionList" id="questionGit"
-                                           class="form-control" placeholder="git 주소를 업로드 해주세요."
-                                           th:value="${detail.questionList[0].question}" disabled required=""/>
-                                </div>
-
-
-                                <!-- Company_FAQ 의 질문(question) 컬럼명이 겹침 주의 ! -->
-                                <h5 class="mb-4 mt-4">자주하는 질문</h5><label class="text-warning">*FAQ 수정 필요 시 상단 faq바를 이용해주세요.</label>
-                                <div class="accordion" th:each="faq, faqStat : ${info.faqList}" id="accordionExample">
-                                    <div class="accordion-item mb-3">
-                                        <h2 class="accordion-header" th:id="'heading' + ${faqStat.index}">
-                                            <button class="accordion-button collapsed rounded" type="button"
-                                                    data-bs-toggle="collapse"
-                                                    th:data-bs-target="'#collapse' + ${faqStat.index}"
-                                                    aria-expanded="false"
-                                                    th:aria-controls="'collapse' + ${faqStat.index}">
-                                                <strong th:text="${faq.question}"></strong>
-                                            </button>
-                                        </h2>
-                                        <div th:id="'collapse' + ${faqStat.index}" class="accordion-collapse collapse"
-                                             th:aria-labelledby="'heading' + ${faqStat.index}">
-                                            <div class="accordion-body">
-                                                <strong th:text="${faq.answer}"></strong>
+                                    <div class="custom-card-border row my-1 py-2 px-1 ">
+                                        <div class="row mx-auto">
+                                            <div th:each="job : ${totalJobs}" class="editJobs form-check col-md-4 col-6" style="display: none;">
+                                                <input class="form-check-input" type="radio" th:id="'job'+${job.id}"
+                                                       name="jobIdSet"
+                                                       th:value="${job.id}" th:checked="${jobs != null and jobs.contains(job)}" required />
+                                                <label class="form-check-label" th:text="${job.name}"></label>
+                                            </div>
+                                            <div th:if="${jobs != null}">
+                                                <div th:each="job : ${jobs}" id="jobs" style="display: inline-block;" >
+                                                    <label class="form-check-label bi-person-workspace" th:text="'  '+${job.name}"></label>
+                                                    <br/>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
 
-                                <div class="row">
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>개발 툴<small><span class="text-danger" style="font-size: small"> * 필수</span></small></h6>
+                                    <input type="text" name="tool" id="tool" class="form-control"
+                                           th:value="${detail.tool}" readonly required>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>주요업무 <small class="text-danger" style="font-size: small"> *필수</small> </h6>
+                                    <textarea class="form-control autoresize" rows="5" id="mainTask" name="mainTask"
+                                              th:text="${detail.mainTask}" readonly required></textarea>
+                                </div>
+
+                                <div class="col-12 mx-auto my-3">
+                                    <hr class="my-2">
+                                    <h6>근무조건 <small class="text-danger" style="font-size: small"> *필수</small> </h6>
+                                    <textarea class="form-control autoresize" rows="5" id="workCondition"
+                                              name="workCondition"  th:text="${detail.workCondition}"
+                                              readonly required></textarea>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>자격요건</h6>
+                                    <textarea class="form-control autoresize" rows="5" id="qualification" name="qualification"
+                                              th:text="${detail.qualification}" readonly></textarea>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>우대 기술사항</h6>
+                                    <textarea class="form-control autoresize" rows="5" id="special_skill" name="specialSkill"
+                                              th:text="${detail.specialSkill}" readonly></textarea>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>복지 및 혜택</h6>
+                                    <textarea class="form-control autoresize" rows="5" id="benefit" name="benefit"
+                                              th:text="${detail.benefit}" readonly></textarea>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>채용절차</h6>
+                                    <textarea class="form-control autoresize mb-4" rows="5" id="process" name="process"
+                                              th:text="${detail.process}" readonly required></textarea>
+                                    <hr>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>회사정보<small class="text-secondary" style="font-size: small"> (정보수정 필요 시 기업 페이지에서 변경가능)</small></h6>
+                                    <div class="custom-block-icon-wrap my-2">
+                                        <img class="mx-auto img-fluid rounded-1 d-block" th:src="${info.photo}" name="photo" alt="company-img"/>
+                                    </div>
+                                    <h6 class="my-2"><small>회사명</small></h6>
+                                    <input type="text" readonly name="name" id="name" th:value="${info.name}"
+                                           class="form-control-plaintext" placeholder="회사명" disabled/>
+
+                                    <h6 class="my-2"><small>대표자</small></h6>
+                                    <input type="text" readonly name="ceoName" id="ceoName" th:value="${info.ceoName}"
+                                           class="form-control-plaintext" placeholder="대표자명" disabled/>
+
+                                    <h6 class="my-2"><small>재직인원</small></h6>
+                                    <input type="number" readonly name="employeeNum" id="employeeNum"
+                                           th:value="${info.employeeNum}"
+                                           class="form-control-plaintext" placeholder="재직인원" disabled
+                                           oninput="this.value = this.value.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1');"/>
+
+                                    <h6 class="my-4">기업소개</h6>
+                                    <textarea class="form-control autoresize" rows="5" id="introduction" name="introduction"
+                                              th:value="${info.introduction}" th:text="${info.introduction}"
+                                              readonly></textarea>
+
+                                    <h6 class="my-4">근무지 주소
+                                        <small class="text-secondary" style="font-size: small">(세부주소 포함)</small>
+                                        <small class="text-danger" style="font-size: small">  *필수</small>
+                                    </h6>
+                                    <div class="input-group mb-4">
+                                        <input type="text" name="workAddress" id="address"
+                                               class="form-control" placeholder="근무주소" th:value="${info.address}" readonly required/>
+                                        <button type="button" class="custom-border-option-btn" id="addressInputBtn" style="display: none">주소변경</button>
+                                    </div>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <hr>
+                                    <h6>유의사항</h6>
+                                    <textarea class="form-control autoresize mb-4" rows="5" id="notice" name="notice"
+                                              th:text="${detail.notice}" readonly></textarea>
+                                    <hr>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>MZ 질문</h6>
+                                    <h6 class="my-3"><small>테스트 시작일</small>
+                                        <span class="text-danger" style="font-size: small">
+                                            *필수(분(minute)은 등록되지 않습니다. 예)12:06->12:00) / 시작일은 공고 마감일 이후 시점 등록가능
+                                        </span>
+                                    </h6>
+                                    <input type="datetime-local" name="testStartDate" id="testStartDate"
+                                           class="form-control mb-2" placeholder="test_start"
+                                           th:value="${detail.testStartDate}" disabled required=""/>
+                                    <h6 class="my-3"><small>테스트 종료일</small>
+                                        <span class="text-danger" style="font-size: small">
+                                            *필수(분(minute)은 등록되지 않습니다. 예)12:06->12:00)
+                                        </span>
+                                    </h6>
+                                    <input type="datetime-local" name="testEndDate" id="testEndDate"
+                                           class="form-control mb-2" placeholder="test_end"
+                                           th:value="${detail.testEndDate}"
+                                           disabled required=""/>
+                                    <h6 class="my-3"><small>테스트 링크</small>
+                                        <span class="text-danger" style="font-size: small">
+                                            *필수
+                                        </span>
+                                    </h6>
+                                    <input type="hidden" name="idList" th:value="${detail.questionList[0].id}"/>
+                                    <input type="url" name="questionList" id="questionGit"
+                                           class="form-control mb-2" placeholder="git 주소를 업로드 해주세요."
+                                           th:value="${detail.questionList[0].question}" disabledrequired=""/>
+                                </div>
+
+
+
+
+                                <!-- Company_FAQ 의 질문(question) 컬럼명이 겹침 주의 ! -->
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>자주하는 질문
+                                        <small class="text-secondary" style="font-size: small">
+                                            FAQ 수정 필요 시 상단 faq바를 이용해주세요.
+                                        </small>
+                                    </h6>
+                                    <div class="accordion" th:each="faq, faqStat : ${info.faqList}" id="accordionExample">
+                                        <div class="accordion-item mb-3">
+                                            <h2 class="accordion-header" th:id="'heading' + ${faqStat.index}">
+                                                <button class="accordion-button collapsed rounded" type="button"
+                                                        data-bs-toggle="collapse"
+                                                        th:data-bs-target="'#collapse' + ${faqStat.index}"
+                                                        aria-expanded="false"
+                                                        th:aria-controls="'collapse' + ${faqStat.index}">
+                                                    <strong th:text="${faq.question}"></strong>
+                                                </button>
+                                            </h2>
+                                            <div th:id="'collapse' + ${faqStat.index}" class="accordion-collapse collapse"
+                                                 th:aria-labelledby="'heading' + ${faqStat.index}">
+                                                <div class="accordion-body">
+                                                    <strong th:text="${faq.answer}"></strong>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="row post-form">
+                                    <div class="col-3 pt-4 m-auto">
+                                        <button type="button" id="goBackListBtn" class="form-control" onclick="goBackList()">목록</button>
+                                    </div>
                                     <div class="col-3 pt-4 m-auto">
                                         <button type="button" th:unless="${detail.closed}" class="form-control"
                                                 id="editBtn" onclick="enableEditing()">수정하기
@@ -552,14 +517,14 @@
                                     </div>
                                 </div>
 
-                                <div class="row">
+                                <div class="row post-form">
                                     <div class="col-3 pt-4 m-auto">
                                         <button type="submit" class="form-control" id="submitEdit"
                                                 style="display:none;">수정완료
                                         </button>
                                     </div>
                                     <div class="col-3 pt-4 m-auto">
-                                        <button type="button" class="form-control" id="cancelBtn"
+                                        <button type="button" class="form-control rounded-pill" id="cancelBtn"
                                                 onclick="cancelEditing()" style="display:none;">취소
                                         </button>
                                     </div>

--- a/src/main/resources/templates/company/normal-post.html
+++ b/src/main/resources/templates/company/normal-post.html
@@ -8,10 +8,18 @@
     <script>
         /* 자소서 질문 추가 (임시) */
         function add_item() {
-            // pre_set 에 있는 내용을 읽어와서 처리..
-            var div = document.createElement('div');
-            div.innerHTML = document.getElementById('pre_set').innerHTML;
-            document.getElementById('field').appendChild(div);
+            var field = document.getElementById('field');
+            var currentItems = field.getElementsByClassName('input-group').length;
+
+            // 현재 항목 개수가 4개 미만인 경우에만 추가
+            if (currentItems < 4) {
+                var div = document.createElement('div');
+                div.innerHTML = document.getElementById('pre_set').innerHTML;
+                div.className = 'input-group my-2';
+                field.appendChild(div);
+            } else {
+                alert('더 이상 추가할 수 없습니다.'); // 사용자에게 알림
+            }
         }
 
         function remove_item(obj) {
@@ -182,7 +190,7 @@
         <section class="latest-podcast-section" id="section_2">
             <div class="container">
                 <div class="section-title-wrap col-8 mb-3 mx-auto">
-                    <h4 class="section-title">공고 등록</h4>
+                    <h4 class="section-title">일반공고 등록</h4>
                 </div>
 
                 <div class="row justify-content-center col-md-9 col-12 mb-5 mx-auto">
@@ -191,44 +199,54 @@
                             <div class="card-body align-self-center mx-auto">
 
                                 <div class="col-12 mx-auto my-3">
-                                    <h6>공고 제목 <small class="text-danger"> *필수</small> </h6>
+                                    <h6>공고 제목 <small class="text-danger" style="font-size: small"> *필수</small> </h6>
                                     <input type="text" name="title" id="title" class="form-control" required />
                                 </div>
 
-                                <div class="row col-12 mx-auto my-4">
+                                <div class="card mt-3 col-12 mx-auto">
                                     <hr>
-                                    <div class="col-4">
-                                        <h6><small>경력<span class="text-danger"> *필수</span></small></h6>
+                                    <div class="mb-1">
+                                        <h6>스택<small><span class="text-danger" style="font-size: small"> *한 개이상 필수 입니다.</span></small></h6>
+                                    </div>
+                                    <div class="custom-card-border row my-1 py-2 px-1"
+                                         data-bs-toggle="tooltip" data-bs-html="true"
+                                    title="우리 회사에서 사용하는 기술스택을 선택해 적절한 인재를 찾으세요.">
+                                        <div class="row mx-auto">
+                                            <div th:each="stack : ${stacks}" class="editJobs form-check col-md-3 col-6">
+                                                <input class="form-check-input" type="checkbox" id="stack" name="stackIdSet"
+                                                       th:value="${stack.id}"
+                                                       th:checked="${stackIdSet != null and stackIdSet.contains(stack)}"/>
+                                                <label class="form-check-label" th:text="${stack.name}"></label>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="row col-12 mx-auto my-4">
+                                    <hr class="mb-1">
+                                    <div class="col-4 mt-2">
+                                        <h6><small>경력<span class="text-danger" style="font-size: small"> *필수</span></small></h6>
                                         <input type="number" name="career" id="career" class="form-control"
                                                placeholder="경력(년)" required=""
                                                oninput="this.value = this.value.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1');"/>
                                     </div>
-                                    <div class="col-8">
+                                    <div class="col-8 mt-2">
                                         <h6><small>마감일<span class="text-danger" style="font-size: small"> *필수(분(minute)은 등록되지 않습니다. 예)12:06:12->12:00:00)</span></small></h6>
                                         <input type="datetime-local" name="endDate" id="endDate"
                                                class="form-control" placeholder="마감일" required=""/>
                                     </div>
                                 </div>
 
-                                <!--<div class="col-12 mx-auto my-3">
-                                    <hr>
-                                    <h6>직무</h6>
-                                    <div th:each="job, jobStat : ${jobs}" style="display: inline-block;">
-                                        <input class="form-check-input" type="radio" id="job" name="jobIdSet"
-                                               th:value="${job.id}" required/>
-                                        <label class="form-check-label" th:text="${job.name}"></label>
-                                    </div>
-                                </div>-->
 
                                 <div class="card mt-3 col-12 mx-auto">
                                     <hr>
                                     <div class="mb-1">
-                                        <h6>직무<small><span class="text-danger"> *필수</span></small></h6>
+                                        <h6>직무<small><span class="text-danger" style="font-size: small"> *필수</span></small></h6>
                                     </div>
                                     <div class="custom-card-border row my-1 py-2 px-1 ">
                                         <div class="row mx-auto">
-                                            <div th:each="job, jobStat : ${jobs}" class="editJobs form-check col-md-4 col-6 mx-auto">
-                                                <input class="form-check-input" type="checkbox" id="job"
+                                            <div th:each="job, jobStat : ${jobs}" class="editJobs form-check col-md-4 col-6">
+                                                <input class="form-check-input" type="radio" id="job"
                                                        name="jobIdSet" th:value="${job.id}" required />
                                                 <label class="form-check-label" th:text="${job.name}"></label>
                                             </div>
@@ -236,189 +254,131 @@
                                     </div>
                                 </div>
 
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>개발 툴<small><span class="text-danger" style="font-size: small"> * 필수</span></small></h6>
+                                    <input type="text" name="tool" id="tool" class="form-control" required>
+                                </div>
 
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="stackId">요구스택</label><label class="text-danger">     *하나 이상 필수</label>
-                                    </div>
-                                    <div th:each="stack, stackStat : ${stacks}" style="display: inline-block;">
-                                        <input class="form-check-input" type="checkbox" id="stack" name="stackIdSet"
-                                               th:value="${stack.id}"/>
-                                        <label class="form-check-label" th:text="${stack.name}"></label>
-                                    </div>
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>주요업무 <small class="text-danger" style="font-size: small"> *필수</small> </h6>
+                                    <textarea class="form-control autoresize" rows="5" id="mainTask" name="mainTask" required></textarea>
+                                </div>
 
+                                <div class="col-12 mx-auto my-3">
+                                    <hr class="my-2">
+                                    <h6>근무조건 <small class="text-danger" style="font-size: small"> *필수</small> </h6>
+                                    <textarea class="form-control autoresize" rows="5" id="workCondition" name="workCondition" required></textarea>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>자격요건</h6>
+                                    <textarea class="form-control autoresize" rows="5" id="qualification" name="qualification"></textarea>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>우대 기술사항</h6>
+                                    <textarea class="form-control autoresize" rows="5" id="special_skill" name="specialSkill"></textarea>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>복지 및 혜택</h6>
+                                    <textarea class="form-control autoresize" rows="5" id="benefit" name="benefit"></textarea>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>채용절차</h6>
+                                    <textarea class="form-control autoresize mb-4" rows="5" id="process" name="process" required></textarea>
+                                    <hr>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>회사정보<small class="text-secondary" style="font-size: small"> (정보수정 필요 시 기업 페이지에서 변경가능)</small></h6>
+                                    <div class="custom-block-icon-wrap my-2">
+                                        <img class="mx-auto img-fluid rounded-1 d-block" th:src="${info.photo}" name="photo" alt="company-img"/>
+                                    </div>
+                                    <h6 class="my-2"><small>회사명</small></h6>
+                                    <input type="text" readonly name="name" id="name" th:value="${info.name}"
+                                           class="form-control-plaintext" placeholder="회사명" disabled/>
+
+                                    <h6 class="my-2"><small>대표자</small></h6>
+                                    <input type="text" readonly name="ceoName" id="ceoName" th:value="${info.ceoName}"
+                                           class="form-control-plaintext" placeholder="대표자명" disabled/>
+
+                                    <h6 class="my-2"><small>재직인원</small></h6>
+                                    <input type="number" readonly name="employeeNum" id="employeeNum"
+                                           th:value="${info.employeeNum}"
+                                           class="form-control-plaintext" placeholder="재직인원" disabled
+                                           oninput="this.value = this.value.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1');"/>
+
+                                    <h6 class="my-4">기업소개</h6>
+                                    <textarea class="form-control autoresize" rows="5" id="introduction" name="introduction"
+                                              th:value="${info.introduction}" th:text="${info.introduction}"
+                                              readonly></textarea>
+
+                                    <h6 class="my-4">근무지 주소
+                                        <small class="text-secondary" style="font-size: small">(세부주소 포함)</small>
+                                        <small class="text-danger" style="font-size: small">  *필수</small>
+                                    </h6>
+                                    <div class="input-group mb-4">
+                                        <input type="text" name="workAddress" id="address"
+                                               class="form-control" placeholder="근무주소" th:value="${info.address}" required/>
+                                        <button type="button" class="custom-border-option-btn" id="addressInputBtn">주소변경</button>
+                                    </div>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <hr>
+                                    <h6>유의사항</h6>
+                                    <textarea class="form-control autoresize mb-4" rows="5" id="notice" name="notice"></textarea>
+                                    <hr>
                                 </div>
 
 
-                                <div class="col-8 mt-4">
-                                    <h4 class="mb-2">회사 정보</h4><label class="text-warning">*회사 정보 수정 필요 시 기업페이지에서 해주세요</label>
-                                    <!--
-                                     회사명 : name
-                                     대표자 : ceoName
-                                     재직인원 : employeeNum
-                                     근무주소(디폴트 회사 주소) : address
-                                     사진 : photo
-                                     -->
-                                    <div class="row">
-                                        <div class="col-4 mt-2">
-                                            <div class="mb-1">
-                                                <label for="name">회사명</label>
-                                            </div>
-                                            <input type="text" name="name" id="name" th:value="${info.name}"
-                                                   class="form-control" placeholder="회사명" disabled/>
-                                        </div>
-                                        <div class="col-4 mt-2">
-                                            <div class="mb-1">
-                                                <label for="ceoName">대표자명</label>
-                                            </div>
-                                            <input type="text" name="ceoName" id="ceoName" th:value="${info.ceoName}"
-                                                   class="form-control" placeholder="대표자명" disabled/>
-                                        </div>
-                                        <div class="col-4 mt-2">
-                                            <div class="mb-1">
-                                                <label for="employeeNum">재직인원</label>
-                                            </div>
-                                            <input type="number" name="employeeNum" id="employeeNum"
-                                                   th:value="${info.employeeNum}"
-                                                   class="form-control" placeholder="재직인원" disabled
-                                                   oninput="this.value = this.value.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1');"/>
-                                        </div>
-                                        <div class="col-lg-4 col-12">
-                                            <div class="custom-block-icon-wrap">
-                                                <div class="custom-block-image-wrap custom-block-image-detail-page">
-                                                    <img th:src="${info.photo}" class="custom-block-image img-fluid" alt="">
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>자기소개서 문항등록
+                                        <small class="text-danger mx-1" style="font-size: small">
+                                            *하나 이상 문항을 입력해주세요.</small>
+                                        <button class="custom-border-option-btn mx-1" type="button" onclick="add_item()">+</button>
+                                    </h6>
+                                    <div class="input-group my-2" id="pre_set">
+                                        <input type="text" class="form-control" id="questionList" name="questionList" required value="">
+                                        <input type="button" class="btn btn-outline-secondary" value="삭제" onclick="remove_item(this)">
+                                    </div>
+                                    <div id="field"></div>
+                                    <span style="font-size: small">최대 5개 등록 가능합니다.</span>
+                                </div>
+
+                                <!-- Company_FAQ 의 질문(question) 컬럼명이 겹침 주의 ! -->
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>자주하는 질문
+                                        <small class="text-secondary" style="font-size: small">
+                                            FAQ 수정 필요 시 상단 faq바를 이용해주세요.
+                                        </small>
+                                    </h6>
+                                    <div class="accordion" th:each="faq, faqStat : ${info.faqList}" id="accordionExample">
+                                        <div class="accordion-item mb-3">
+                                            <h2 class="accordion-header" th:id="'heading' + ${faqStat.index}">
+                                                <button class="accordion-button collapsed rounded" type="button"
+                                                        data-bs-toggle="collapse"
+                                                        th:data-bs-target="'#collapse' + ${faqStat.index}"
+                                                        aria-expanded="false"
+                                                        th:aria-controls="'collapse' + ${faqStat.index}">
+                                                    <strong th:text="${faq.question}"></strong>
+                                                </button>
+                                            </h2>
+                                            <div th:id="'collapse' + ${faqStat.index}" class="accordion-collapse collapse"
+                                                 th:aria-labelledby="'heading' + ${faqStat.index}">
+                                                <div class="accordion-body">
+                                                    <strong th:text="${faq.answer}"></strong>
                                                 </div>
                                             </div>
                                         </div>
-
-                                    </div>
-
-                                </div>
-                                <!--
-                                    기업소개(기업테이블) : introduction
-                                    주요업무 : mainTask
-                                    근무조건 : workCondition
-                                    자격요건 : qualification
-                                    개발 툴 : tool
-                                    복지 및 혜택 : benefit
-                                    우대 기술사항 : special_skill
-                                    채용절차 : process
-                                    유의사항 : notice
-
-                                -->
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="introduction">기업소개</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="introduction" name="introduction"
-                                              th:value="${info.introduction}" th:text="${info.introduction}"
-                                              readonly></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="mainTask">주요업무</label><label class="text-danger">     *필수</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="mainTask" name="mainTask" required></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="workCondition">근무조건</label><label class="text-danger">     *필수</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="workCondition"
-                                              name="workCondition" required></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="qualification">자격요건</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="qualification"
-                                              name="qualification"></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="tool">개발 툴</label><label class="text-danger">     *필수</label>
-                                        <input type="text" name="tool" id="tool"
-                                               class="form-control" required>
-                                    </div>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="benefit">복지 및 혜택</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="benefit" name="benefit"></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="special_skill">우대 기술사항</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="special_skill"
-                                              name="specialSkill"></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="process">채용절차</label><label class="text-danger">     *필수</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="process" name="process" required></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="notice">유의사항</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="notice" name="notice"></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="address">근무주소(세부주소 포함)</label><label class="text-danger">     *필수</label>
-                                    </div>
-                                    <input type="text" name="workAddress" id="address"
-                                           class="form-control mb-2" placeholder="근무주소" th:value="${info.address}" required/>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="form-floating">
-                                        <button type="button" class="custom-btn" id="addressInputBtn">주소변경</button>
                                     </div>
                                 </div>
 
-                                <h5 class="mb-4 mt-4" style="display: inline-block;">자기소개서 질문</h5><label class="text-danger"> *하나 이상 문항을 입력해주세요.</label>
-                                <button class="btn m-lg-3" type="button" onclick="add_item()">+</button>
-                                <br>
-
-                                <div class="col-12 mb-4" id="pre_set">
-                                    <input type="text" class="form-control" id="questionList" name="questionList" required value="">
-                                    <input type="button" class="form-control" value="삭제" onclick="remove_item(this)">
-                                </div>
-
-                                <div id="field"></div>
-
-
-                                최대 5개 등록 가능합니다.
-
-
-                                <!-- Company_FAQ 의 질문(question) 컬럼명이 겹침 주의 ! -->
-                                <h5 class="mb-4 mt-4">자주하는 질문</h5><label class="text-warning">*FAQ 수정 필요 시 상단 faq바를 이용해주세요.</label>
-                                <div class="accordion" th:each="faq, faqStat : ${info.faqList}" id="accordionExample">
-                                    <div class="accordion-item mb-3">
-                                        <h2 class="accordion-header" th:id="'heading' + ${faqStat.index}">
-                                            <button class="accordion-button collapsed rounded" type="button"
-                                                    data-bs-toggle="collapse"
-                                                    th:data-bs-target="'#collapse' + ${faqStat.index}"
-                                                    aria-expanded="false"
-                                                    th:aria-controls="'collapse' + ${faqStat.index}">
-                                                <strong th:text="${faq.question}"></strong>
-                                            </button>
-                                        </h2>
-                                        <div th:id="'collapse' + ${faqStat.index}" class="accordion-collapse collapse"
-                                             th:aria-labelledby="'heading' + ${faqStat.index}">
-                                            <div class="accordion-body">
-                                                <strong th:text="${faq.answer}"></strong>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div class="col-6 pt-4 m-auto">
-                                    <input type="hidden" name="postType" value="NORMAL"/>
-                                    <button type="submit" class="form-control">등록하기</button>
+                                <input type="hidden" name="postType" value="NORMAL"/>
+                                <div class="col-12 my-3 pt-4 d-flex justify-content-center ">
+                                    <button type="submit" class="custom-btn">등록하기</button>
                                 </div>
 
 

--- a/src/main/resources/templates/company/normal-post.html
+++ b/src/main/resources/templates/company/normal-post.html
@@ -181,48 +181,58 @@
 
         <section class="latest-podcast-section" id="section_2">
             <div class="container">
-                <div class="section-title-wrap mb-5">
+                <div class="section-title-wrap col-8 mb-3 mx-auto">
                     <h4 class="section-title">공고 등록</h4>
                 </div>
-                <div class="row justify-content-center">
-                    <div class="card bg-outline-light text-dark ">
-                        <form action="/v1/company/post/create" method="post" class="post-form" role="form" onsubmit="return validateForm()">
-                            <div class="card-body">
 
-                                <div class="col-8">
-                                    <div class="mb-1">
-                                        <label for="title">공고 제목</label><label class="text-danger">     *필수</label>
-                                    </div>
-                                    <input type="text" name="title" id="title"
-                                           class="form-control" placeholder="공고제목" required/>
+                <div class="row justify-content-center col-md-9 col-12 mb-5 mx-auto">
+                    <div class="card bg-outline-light text-dark shadow-lg col-md-12 col-12 mt-1 mb-5">
+                        <form action="/v1/company/post/create" method="post" class="row col-md-11 col-12 mx-auto" role="form" onsubmit="return validateForm()">
+                            <div class="card-body align-self-center mx-auto">
+
+                                <div class="col-12 mx-auto my-3">
+                                    <h6>공고 제목 <small class="text-danger"> *필수</small> </h6>
+                                    <input type="text" name="title" id="title" class="form-control" required />
                                 </div>
-                                <div class="row">
-                                    <div class="col-4 mt-2 ">
-                                        <div class="mb-1">
-                                            <label for="endDate">마감일</label><label class="text-danger">     *필수(분(minute)은 등록되지 않습니다. 예)12:06:12->12:00:00)</label>
-                                        </div>
-                                        <input type="datetime-local" name="endDate" id="endDate"
-                                               class="form-control" placeholder="마감일" required=""/>
-                                    </div>
-                                    <div class="col-4 mt-2">
-                                        <div class="mb-1">
-                                            <label for="career">경력</label><label class="text-danger">     *필수</label>
-                                        </div>
+
+                                <div class="row col-12 mx-auto my-4">
+                                    <hr>
+                                    <div class="col-4">
+                                        <h6><small>경력<span class="text-danger"> *필수</span></small></h6>
                                         <input type="number" name="career" id="career" class="form-control"
                                                placeholder="경력(년)" required=""
                                                oninput="this.value = this.value.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1');"/>
                                     </div>
+                                    <div class="col-8">
+                                        <h6><small>마감일<span class="text-danger" style="font-size: small"> *필수(분(minute)은 등록되지 않습니다. 예)12:06:12->12:00:00)</span></small></h6>
+                                        <input type="datetime-local" name="endDate" id="endDate"
+                                               class="form-control" placeholder="마감일" required=""/>
+                                    </div>
                                 </div>
 
-
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="jobId">직무</label><label class="text-danger">     *필수</label>
-                                    </div>
+                                <!--<div class="col-12 mx-auto my-3">
+                                    <hr>
+                                    <h6>직무</h6>
                                     <div th:each="job, jobStat : ${jobs}" style="display: inline-block;">
                                         <input class="form-check-input" type="radio" id="job" name="jobIdSet"
                                                th:value="${job.id}" required/>
                                         <label class="form-check-label" th:text="${job.name}"></label>
+                                    </div>
+                                </div>-->
+
+                                <div class="card mt-3 col-12 mx-auto">
+                                    <hr>
+                                    <div class="mb-1">
+                                        <h6>직무<small><span class="text-danger"> *필수</span></small></h6>
+                                    </div>
+                                    <div class="custom-card-border row my-1 py-2 px-1 ">
+                                        <div class="row mx-auto">
+                                            <div th:each="job, jobStat : ${jobs}" class="editJobs form-check col-md-4 col-6 mx-auto">
+                                                <input class="form-check-input" type="checkbox" id="job"
+                                                       name="jobIdSet" th:value="${job.id}" required />
+                                                <label class="form-check-label" th:text="${job.name}"></label>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
 

--- a/src/main/resources/templates/company/normal-post.html
+++ b/src/main/resources/templates/company/normal-post.html
@@ -212,7 +212,7 @@
                                          data-bs-toggle="tooltip" data-bs-html="true"
                                     title="우리 회사에서 사용하는 기술스택을 선택해 적절한 인재를 찾으세요.">
                                         <div class="row mx-auto">
-                                            <div th:each="stack : ${stacks}" class="editJobs form-check col-md-3 col-6">
+                                            <div th:each="stack : ${stacks}" class="editStacks form-check col-md-3 col-6">
                                                 <input class="form-check-input" type="checkbox" id="stack" name="stackIdSet"
                                                        th:value="${stack.id}"
                                                        th:checked="${stackIdSet != null and stackIdSet.contains(stack)}"/>

--- a/src/main/resources/templates/company/post-detail.html
+++ b/src/main/resources/templates/company/post-detail.html
@@ -35,13 +35,18 @@
             $('#closedBtn').css('display','none');
             $('#removeBtn').css('display','none');
             $('#editBtn').css('display','none');
+            $('#goBackListBtn').css('display','none');
             $('#cancelBtn').css('display','block');
         }
 
         function cancelEditing() {
             var postId = [[${postId}]];
 
-            window.location.href = '/v1/company/post/detail?id=' + postId;
+            window.location.href = '/v1/company/post/detail?id=' + postId + '&postType=NORMAL';
+        }
+
+        function goBackList(){
+            window.location.href = '/v1/company/post/list/1';
         }
 
         /* 주소 변경하기 */
@@ -231,257 +236,219 @@
 
         <section class="latest-podcast-section" id="section_2">
             <div class="container">
-                <div class="section-title-wrap mb-5">
-                    <h4 class="section-title">공고 상세조회</h4>
+                <div class="section-title-wrap col-8 mb-3 mx-auto">
+                    <h4 class="section-title">일반공고 상세조회</h4>
                 </div>
-                <div class="row justify-content-center">
-                    <div class="card bg-outline-light text-dark ">
-                        <form th:action="@{/v1/company/post/update}" method="post" class="post-form" role="form" onsubmit="return validateForm()">
-                            <div class="card-body">
+                <div class="row justify-content-center col-md-9 col-12 mb-5 mx-auto">
+                    <div class="card bg-outline-light text-dark shadow-lg col-md-12 col-12 mt-1 mb-5">
+                        <form th:action="@{/v1/company/post/update}" method="post" class="row col-md-11 col-12 mx-auto" role="form" onsubmit="return validateForm()">
+                            <div class="card-body align-self-center mx-auto">
 
-                                <div class="col-8">
-                                    <div class="mb-1">
-                                        <label for="title">공고 제목</label><label class="text-danger">     *필수</label>
-                                    </div>
+                                <div class="col-12 mx-auto my-3">
+                                    <h6>공고 제목 <small class="text-danger" style="font-size: small"> *필수</small> </h6>
                                     <input type="text" name="title" id="title"
-                                           class="form-control" placeholder="공고제목" th:value="${detail.title}" readonly required/>
-                                </div>
-                                <div class="row">
-                                    <div class="col-4 mt-2 ">
-                                        <div class="mb-1">
-                                            <label for="endDate">마감일</label><label class="text-danger">     *필수(분(minute)은 등록되지 않습니다. 예)12:06:12->12:00:00)</label>
-                                        </div>
-                                        <input type="datetime-local" name="endDate" id="endDate"
-                                               class="form-control" placeholder="마감일" th:value="${detail.endDate}"
-                                               readonly required/>
-                                    </div>
-                                    <div class="col-4 mt-2">
-                                        <div class="mb-1">
-                                            <label for="career">경력</label><label class="text-danger">     *필수</label>
-                                        </div>
-                                        <input type="number" name="career" id="career" class="form-control"
-                                               placeholder="경력(년)" th:value="${detail.career}" readonly required
-                                               oninput="this.value = this.value.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1');"/>
-                                    </div>
+                                           class="form-control" th:value="${detail.title}" readonly required />
                                 </div>
 
-
-                                <div class="col-8 mt-2">
+                                <div class="card mt-3 col-12 mx-auto">
+                                    <hr>
                                     <div class="mb-1">
-                                        <label for="jobId">직무</label><label class="text-danger">     *필수</label>
+                                        <h6>스택<small><span class="text-danger" style="font-size: small"> *한 개이상 필수 입니다.</span></small></h6>
                                     </div>
-                                    <div th:each="job : ${totalJobs}" class="editJobs" style="display: none;" >
-                                        <input class="form-check-input" type="radio" th:id="'job'+${job.id}"
-                                               name="jobIdSet"
-                                               th:value="${job.id}" th:checked="${jobs != null and jobs.contains(job)}" required/>
-                                        <label class="form-check-label" th:text="${job.name}"></label>
-                                        <br/>
-                                    </div>
-                                    <div th:if="${jobs != null}">
-                                        <div th:each="job : ${jobs}" id="jobs" style="display: inline-block;" >
-                                            <label class="form-check-label bi-person-workspace" th:text="'  '+${job.name}"></label>
-                                            <br/>
-                                        </div>
-                                    </div>
-                                </div>
-
-
-
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="stackId">요구스택</label><label class="text-danger">     *하나 이상 필수</label>
-                                    </div>
-                                    <div th:each="stack : ${totalStacks}" class="editStacks" style="display: none;" >
-                                        <input class="form-check-input" type="checkbox" th:id="'stack'+${stack.id}"
-                                               name="stackIdSet"
-                                               th:value="${stack.id}" th:checked="${stacks != null and stacks.contains(stack)}"/>
-                                        <label class="form-check-label" th:text="${stack.name}"></label>
-                                        <br/>
-                                    </div>
-                                    <div th:if="${stacks != null}">
-                                        <div th:each="stack : ${stacks}" id="stacks" style="display: inline-block;">
-                                            <label class="form-check-label bi-view-stacked" th:text="'  '+${stack.name}"></label>
-                                            <br/>
-                                        </div>
-                                    </div>
-
-                                </div>
-
-
-                                <div class="col-8 mt-4">
-                                    <h4 class="mb-2">회사 정보</h4><label class="text-warning">*회사 정보 수정 필요 시 기업페이지에서 해주세요</label>
-                                    <!--
-                                     회사명 : name
-                                     대표자 : ceoName
-                                     재직인원 : employeeNum
-                                     근무주소(디폴트 회사 주소) : address
-                                     사진 : photo
-                                     -->
-                                    <div class="row">
-                                        <div class="col-4 mt-2">
-                                            <div class="mb-1">
-                                                <label for="name">회사명</label>
+                                    <div class="custom-card-border row my-1 py-2 px-1"
+                                         data-bs-toggle="tooltip" data-bs-html="true"
+                                         title="우리 회사에서 사용하는 기술스택을 선택해 적절한 인재를 찾으세요.">
+                                        <div class="row mx-auto">
+                                            <div th:each="stack : ${totalStacks}" class="editStacks form-check col-md-3 col-6" style="display: none;">
+                                                <input class="form-check-input" type="checkbox" th:id="'stack'+${stack.id}"
+                                                       name="stackIdSet" th:value="${stack.id}"
+                                                       th:checked="${stacks != null and stacks.contains(stack)}"/>
+                                                <label class="form-check-label" th:text="${stack.name}"></label>
                                             </div>
-                                            <input type="text" name="name" id="name" th:value="${info.name}"
-                                                   class="form-control" placeholder="회사명" disabled/>
-                                        </div>
-                                        <div class="col-4 mt-2">
-                                            <div class="mb-1">
-                                                <label for="ceoName">대표자명</label>
-                                            </div>
-                                            <input type="text" name="ceoName" id="ceoName" th:value="${info.ceoName}"
-                                                   class="form-control" placeholder="대표자명" disabled/>
-                                        </div>
-                                        <div class="col-4 mt-2">
-                                            <div class="mb-1">
-                                                <label for="employeeNum">재직인원</label>
-                                            </div>
-                                            <input type="number" name="employeeNum" id="employeeNum"
-                                                   th:value="${info.employeeNum}"
-                                                   class="form-control" placeholder="재직인원" disabled
-                                                   oninput="this.value = this.value.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1');"/>
-                                        </div>
-
-                                        <div class="col-lg-4 col-12">
-                                            <div class="custom-block-icon-wrap">
-                                                <div class="custom-block-image-wrap custom-block-image-detail-page">
-                                                    <img th:src="${info.photo}" class="custom-block-image img-fluid" alt="">
+                                            <div th:if="${stacks != null}">
+                                                <div th:each="stack : ${stacks}" id="stacks" style="display: inline-block;">
+                                                    <label class="form-check-label bi-view-stacked" th:text="'  '+${stack.name}"></label>
+                                                    <br/>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
-
                                 </div>
 
-                                <!--
-                                    기업소개(기업테이블) : introduction
-                                    주요업무 : mainTask
-                                    근무조건 : workCondition
-                                    자격요건 : qualification
-                                    개발 툴 : tool
-                                    복지 및 혜택 : benefit
-                                    우대 기술사항 : special_skill
-                                    채용절차 : process
-                                    유의사항 : notice
-
-                                -->
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="introduction">기업소개</label>
+                                <div class="row col-12 mx-auto my-4">
+                                    <hr class="mb-1">
+                                    <div class="col-4 mt-2">
+                                        <h6><small>경력<span class="text-danger" style="font-size: small"> *필수</span></small></h6>
+                                        <input type="number" name="career" id="career" class="form-control"
+                                               placeholder="경력(년)"  th:value="${detail.career}" readonly required=""
+                                               oninput="this.value = this.value.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1');"/>
                                     </div>
-                                    <textarea class="form-control" rows="3" id="introduction" name="introduction"
-                                              th:value="${info.introduction}" th:text="${info.introduction}"
-                                              readonly></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="mainTask">주요업무</label><label class="text-danger">     *필수</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="mainTask" name="mainTask"
-                                              th:text="${detail.mainTask}" readonly required></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="workCondition">근무조건</label><label class="text-danger">     *필수</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="workCondition"
-                                              name="workCondition" th:text="${detail.workCondition}"
-                                              readonly required></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="qualification">자격요건</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="qualification"
-                                              name="qualification" th:text="${detail.qualification}"
-                                              readonly></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="tool">개발 툴</label><label class="text-danger">     *필수</label>
-                                        <input type="text" name="tool" id="tool"
-                                               class="form-control" th:value="${detail.tool}" readonly required/>
-                                    </div>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="benefit">복지 및 혜택</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="benefit" name="benefit"
-                                              th:text="${detail.benefit}" readonly></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="special_skill">우대 기술사항</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="specialSkill"
-                                              name="specialSkill" th:text="${detail.specialSkill}" readonly></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="process">채용절차</label><label class="text-danger">     *필수</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="process" name="process"
-                                              th:text="${detail.process}" readonly required></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="notice">유의사항</label>
-                                    </div>
-                                    <textarea class="form-control" rows="3" id="notice" name="notice"
-                                              th:text="${detail.notice}" readonly></textarea>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="mb-1">
-                                        <label for="address">근무주소(세부주소 포함)</label><label class="text-danger">     *필수</label>
-                                    </div>
-                                    <input type="text" name="workAddress" id="address"
-                                           class="form-control mb-2" placeholder="근무주소" th:value="${detail.workAddress}"
-                                           readonly required/>
-                                </div>
-                                <div class="col-8 mt-2">
-                                    <div class="form-floating">
-                                        <button type="button" class="custom-btn" id="addressInputBtn"
-                                                style="display: none">주소변경
-                                        </button>
-                                    </div>
-                                </div>
-
-                                <h5 class="mb-4 mt-4" style="display: inline-block;">자기소개서 질문</h5>
-                                <br>
-
-                                <div class="col-12 mb-4"
-                                     th:each="question : ${detail.questionList}">
-                                    <div>
-                                        <input type="hidden" class="form-control" name="idList" th:value="${question.id}" />
-                                        <input type="text" th:id="'question' + ${question.id}" name="questionList" class="form-control" th:value="${question.question}" disabled required/>
+                                    <div class="col-8 mt-2">
+                                        <h6><small>마감일<span class="text-danger" style="font-size: small"> *필수(분(minute)은 등록되지 않습니다. 예)12:06:12->12:00:00)</span></small></h6>
+                                        <input type="datetime-local" name="endDate" id="endDate"
+                                               class="form-control" placeholder="마감일" th:value="${detail.endDate}"
+                                               readonly required=""/>
                                     </div>
                                 </div>
 
 
-                                <!-- Company_FAQ 의 질문(question) 컬럼명이 겹침 주의 ! -->
-                                <h5 class="mb-4 mt-4">자주하는 질문</h5><label class="text-warning">*FAQ 수정 필요 시 상단 faq바를 이용해주세요.</label>
-                                <div class="accordion" th:each="faq, faqStat : ${info.faqList}" id="accordionExample">
-                                    <div class="accordion-item mb-3">
-                                        <h2 class="accordion-header" th:id="'heading' + ${faqStat.index}">
-                                            <button class="accordion-button collapsed rounded" type="button"
-                                                    data-bs-toggle="collapse"
-                                                    th:data-bs-target="'#collapse' + ${faqStat.index}"
-                                                    aria-expanded="false"
-                                                    th:aria-controls="'collapse' + ${faqStat.index}">
-                                                <strong th:text="${faq.question}"></strong>
-                                            </button>
-                                        </h2>
-                                        <div th:id="'collapse' + ${faqStat.index}" class="accordion-collapse collapse"
-                                             th:aria-labelledby="'heading' + ${faqStat.index}">
-                                            <div class="accordion-body">
-                                                <strong th:text="${faq.answer}"></strong>
+                                <div class="card mt-3 col-12 mx-auto">
+                                    <hr>
+                                    <div class="mb-1">
+                                        <h6>직무<small><span class="text-danger" style="font-size: small"> *필수</span></small></h6>
+                                    </div>
+                                    <div class="custom-card-border row my-1 py-2 px-1 ">
+                                        <div class="row mx-auto">
+                                            <div th:each="job : ${totalJobs}" class="editJobs form-check col-md-4 col-6" style="display: none;">
+                                                <input class="form-check-input" type="radio" th:id="'job'+${job.id}"
+                                                       name="jobIdSet"
+                                                       th:value="${job.id}" th:checked="${jobs != null and jobs.contains(job)}" required />
+                                                <label class="form-check-label" th:text="${job.name}"></label>
+                                            </div>
+                                            <div th:if="${jobs != null}">
+                                                <div th:each="job : ${jobs}" id="jobs" style="display: inline-block;" >
+                                                    <label class="form-check-label bi-person-workspace" th:text="'  '+${job.name}"></label>
+                                                    <br/>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
 
-                                <div class="row">
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>개발 툴<small><span class="text-danger" style="font-size: small"> * 필수</span></small></h6>
+                                    <input type="text" name="tool" id="tool" class="form-control"
+                                           th:value="${detail.tool}" readonly required>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>주요업무 <small class="text-danger" style="font-size: small"> *필수</small> </h6>
+                                    <textarea class="form-control autoresize" rows="5" id="mainTask" name="mainTask"
+                                              th:text="${detail.mainTask}" readonly required></textarea>
+                                </div>
+
+                                <div class="col-12 mx-auto my-3">
+                                    <hr class="my-2">
+                                    <h6>근무조건 <small class="text-danger" style="font-size: small"> *필수</small> </h6>
+                                    <textarea class="form-control autoresize" rows="5" id="workCondition"
+                                              name="workCondition"  th:text="${detail.workCondition}"
+                                              readonly required></textarea>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>자격요건</h6>
+                                    <textarea class="form-control autoresize" rows="5" id="qualification" name="qualification"
+                                              th:text="${detail.qualification}" readonly></textarea>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>우대 기술사항</h6>
+                                    <textarea class="form-control autoresize" rows="5" id="special_skill" name="specialSkill"
+                                              th:text="${detail.specialSkill}" readonly></textarea>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>복지 및 혜택</h6>
+                                    <textarea class="form-control autoresize" rows="5" id="benefit" name="benefit"
+                                              th:text="${detail.benefit}" readonly></textarea>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>채용절차</h6>
+                                    <textarea class="form-control autoresize mb-4" rows="5" id="process" name="process"
+                                              th:text="${detail.process}" readonly required></textarea>
+                                    <hr>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>회사정보<small class="text-secondary" style="font-size: small"> (정보수정 필요 시 기업 페이지에서 변경가능)</small></h6>
+                                    <div class="custom-block-icon-wrap my-2">
+                                        <img class="mx-auto img-fluid rounded-1 d-block" th:src="${info.photo}" name="photo" alt="company-img"/>
+                                    </div>
+                                    <h6 class="my-2"><small>회사명</small></h6>
+                                    <input type="text" readonly name="name" id="name" th:value="${info.name}"
+                                           class="form-control-plaintext" placeholder="회사명" disabled/>
+
+                                    <h6 class="my-2"><small>대표자</small></h6>
+                                    <input type="text" readonly name="ceoName" id="ceoName" th:value="${info.ceoName}"
+                                           class="form-control-plaintext" placeholder="대표자명" disabled/>
+
+                                    <h6 class="my-2"><small>재직인원</small></h6>
+                                    <input type="number" readonly name="employeeNum" id="employeeNum"
+                                           th:value="${info.employeeNum}"
+                                           class="form-control-plaintext" placeholder="재직인원" disabled
+                                           oninput="this.value = this.value.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1');"/>
+
+                                    <h6 class="my-4">기업소개</h6>
+                                    <textarea class="form-control autoresize" rows="5" id="introduction" name="introduction"
+                                              th:value="${info.introduction}" th:text="${info.introduction}"
+                                              readonly></textarea>
+
+                                    <h6 class="my-4">근무지 주소
+                                        <small class="text-secondary" style="font-size: small">(세부주소 포함)</small>
+                                        <small class="text-danger" style="font-size: small">  *필수</small>
+                                    </h6>
+                                    <div class="input-group mb-4">
+                                        <input type="text" name="workAddress" id="address"
+                                               class="form-control" placeholder="근무주소" th:value="${info.address}" readonly required/>
+                                        <button type="button" class="custom-border-option-btn" id="addressInputBtn" style="display: none">주소변경</button>
+                                    </div>
+                                </div>
+
+                                <div class="col-12 mx-auto my-4">
+                                    <hr>
+                                    <h6>유의사항</h6>
+                                    <textarea class="form-control autoresize mb-4" rows="5" id="notice" name="notice"
+                                              th:text="${detail.notice}" readonly></textarea>
+                                    <hr>
+                                </div>
+
+
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>자기소개서 문항
+                                        <small class="text-danger mx-1" style="font-size: small">
+                                            *하나 이상 문항을 입력해주세요.</small>
+                                    </h6>
+                                    <div class="input-group my-2" th:each="question : ${detail.questionList}">
+                                        <input type="hidden" name="idList" th:value="${question.id}" />
+                                        <input type="text" class="form-control"  th:id="'question' + ${question.id}"
+                                               name="questionList" th:value="${question.question}" disabled required>
+                                    </div>
+                                </div>
+
+                                <!-- Company_FAQ 의 질문(question) 컬럼명이 겹침 주의 ! -->
+                                <div class="col-12 mx-auto my-4">
+                                    <h6>자주하는 질문
+                                        <small class="text-secondary" style="font-size: small">
+                                            FAQ 수정 필요 시 상단 faq바를 이용해주세요.
+                                        </small>
+                                    </h6>
+                                    <div class="accordion" th:each="faq, faqStat : ${info.faqList}" id="accordionExample">
+                                        <div class="accordion-item mb-3">
+                                            <h2 class="accordion-header" th:id="'heading' + ${faqStat.index}">
+                                                <button class="accordion-button collapsed rounded" type="button"
+                                                        data-bs-toggle="collapse"
+                                                        th:data-bs-target="'#collapse' + ${faqStat.index}"
+                                                        aria-expanded="false"
+                                                        th:aria-controls="'collapse' + ${faqStat.index}">
+                                                    <strong th:text="${faq.question}"></strong>
+                                                </button>
+                                            </h2>
+                                            <div th:id="'collapse' + ${faqStat.index}" class="accordion-collapse collapse"
+                                                 th:aria-labelledby="'heading' + ${faqStat.index}">
+                                                <div class="accordion-body">
+                                                    <strong th:text="${faq.answer}"></strong>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+
+                                <div class="row post-form">
+                                    <div class="col-3 pt-4 m-auto">
+                                        <button type="button" id="goBackListBtn" class="form-control" onclick="goBackList()">목록</button>
+                                    </div>
                                     <div class="col-3 pt-4 m-auto">
                                         <button type="button" th:unless="${detail.closed}" class="form-control" id="editBtn" onclick="enableEditing()">수정하기</button>
                                     </div>
@@ -495,12 +462,12 @@
                                     </div>
                                 </div>
 
-                                <div class="row">
+                                <div class="row post-form">
                                     <div class="col-3 pt-4 m-auto">
-                                        <button type="submit" class="form-control" id="submitEdit" style="display:none;">수정완료</button>
+                                        <button type="button" class="form-control rounded-pill" id="cancelBtn" onclick="cancelEditing()" style="display:none;">취소</button>
                                     </div>
                                     <div class="col-3 pt-4 m-auto">
-                                        <button type="button" class="form-control" id="cancelBtn" onclick="cancelEditing()" style="display:none;">취소</button>
+                                        <button type="submit" class="form-control" id="submitEdit" style="display:none;">수정완료</button>
                                     </div>
                                 </div>
 

--- a/src/main/resources/templates/company/post-list.html
+++ b/src/main/resources/templates/company/post-list.html
@@ -117,8 +117,8 @@
                     </div>
 
                     <!-- 목록 페이지 시작 -->
-                    <div class="col-lg-12 col-12 mb-4 mb-lg-0 text-center" th:if="${#lists.size(postPage) == 0 or postPage==null}">
-                        <h5>공고가 없습니다.</h5>
+                    <div class="col-lg-12 col-12 my-4 mb-lg-0 text-center" th:if="${#lists.size(postPage) == 0 or postPage==null}">
+                        <h5 class="my-4">공고가 없습니다.</h5>
                     </div>
                     <!-- 목록 1칸 -->
                     <div class="col-lg-10 col-12 mb-4 mb-lg-2 post-form" th:each="postList, postListStat : ${postPage}"

--- a/src/main/resources/templates/company/post-list.html
+++ b/src/main/resources/templates/company/post-list.html
@@ -81,39 +81,49 @@
                     </div>
 
 
-                    <div class="row">
-                        <div class="col-lg-5 col-12 mb-3 d-flex justify-content-center">
-                            <div class="btn-group">
-                                <button id="latest" type="button" class="btn btn-outline-secondary active" onclick="sort(this)">최신순
-                                </button>
-                                <button id="open" type="button" class="btn btn-outline-secondary" onclick="sort(this)">
-                                    진행중
-                                </button>
-                                <button id="deadline" type="button" class="btn btn-outline-secondary" onclick="sort(this)">마감임박
-                                </button>
-                                <button id="close" type="button" class="btn btn-outline-secondary" onclick="sort(this)">
-                                    마감만
-                                </button>
-                            </div>
-                        </div>
-                        <div class="col-lg-3 col-12">
+                    <div class="row col-12 mx-auto justify-content-center">
 
-                        </div>
-
-                        <div class="col-lg-4 col-12 mb-3 d-flex justify-content-center">
-                            <div class="btn-group">
-                                <button type="button" class="btn btn-outline-success"
-                                        data-bs-toggle="tooltip" data-bs-html="true"
-                                        title="이력서와 자소서로<br>채용을 진행합니다."
-                                        onclick="location.href='/v1/company/post/form'">일반공고 생성
-                                </button>
-                                <button type="button" class="btn btn-outline-primary"
-                                        data-bs-toggle="tooltip" data-bs-html="true"
-                                        title="서류채용이 아닌<br>GitHub로 문제를 출제하여<br>지원자의 실력을 검증합니다."
-                                        onclick="location.href='/v1/company/post/mz/form'">MZ공고 생성
-                                </button>
+                            <div class="col-lg-5 col-12 mb-3 d-flex justify-content-center">
+                                <div class="btn-group">
+                                    <button id="latest" type="button"
+                                            th:classappend="${sort == 'latest' ? 'active' : ''}"
+                                            class="btn btn-outline-secondary" onclick="sort(this)">최신순
+                                    </button>
+                                    <button id="open" type="button"
+                                            th:classappend="${sort == 'open' ? 'active' : ''}"
+                                            class="btn btn-outline-secondary" onclick="sort(this)">
+                                        진행중
+                                    </button>
+                                    <button id="deadline" type="button"
+                                            th:classappend="${sort == 'deadline' ? 'active' : ''}"
+                                            class="btn btn-outline-secondary" onclick="sort(this)">마감임박
+                                    </button>
+                                    <button id="close" type="button"
+                                            th:classappend="${sort == 'close' ? 'active' : ''}"
+                                            class="btn btn-outline-secondary" onclick="sort(this)">
+                                        마감만
+                                    </button>
+                                </div>
                             </div>
-                        </div>
+                            <div class="col-lg-2 col-12">
+
+                            </div>
+
+                            <div class="col-lg-4 col-12 mb-3 d-flex justify-content-center">
+                                <div class="btn-group">
+                                    <button type="button" class="btn btn-outline-success"
+                                            data-bs-toggle="tooltip" data-bs-html="true"
+                                            title="이력서와 자소서로<br>채용을 진행합니다."
+                                            onclick="location.href='/v1/company/post/form'">일반공고 생성
+                                    </button>
+                                    <button type="button" class="btn btn-outline-primary"
+                                            data-bs-toggle="tooltip" data-bs-html="true"
+                                            title="서류채용이 아닌<br>GitHub로 문제를 출제하여<br>지원자의 실력을 검증합니다."
+                                            onclick="location.href='/v1/company/post/mz/form'">MZ공고 생성
+                                    </button>
+                                </div>
+                            </div>
+
                     </div>
 
                     <!-- 목록 페이지 시작 -->
@@ -121,26 +131,26 @@
                         <h5 class="my-4">공고가 없습니다.</h5>
                     </div>
                     <!-- 목록 1칸 -->
-                    <div class="col-lg-10 col-12 mb-4 mb-lg-2 post-form" th:each="postList, postListStat : ${postPage}"
+                    <div class="col-lg-10 col-12 my-2" th:each="postList, postListStat : ${postPage}"
                          th:id="'postPage'+${postListStat.index}">
-                        <div th:each="post, postStat : ${postList}">
+                        <div class="col-12 my-2 mx-auto" th:each="post, postStat : ${postList}">
                             <div class="custom-block d-flex">
                                 <div class="custom-block-info">
                                     <div class="mb-2 d-inline-flex" th:if="${post.postType=='NORMAL'}">
-                                        <button class="badge" style="background-color: #717275" th:text="일반공고"></button>
+                                        <span class="badge bg-secondary" th:text="일반공고"></span>
                                     </div>
                                     <div class="mb-2 d-inline-flex" th:if="${post.postType=='MZ'}">
-                                        <button class="badge" style="background-color: #0a53be" th:text="MZ공고"></button>
+                                        <span class="badge bg-primary" th:text="MZ공고"></span>
                                     </div>
                                     <div class="mb-2 d-inline-flex" th:if="${post.closed==true}">
-                                        <button class="badge" style="background-color: #b02a37" th:text="마감"></button>
+                                        <span class="badge bg-danger" th:text="마감"></span>
                                     </div>
                                     <h6>
                                         <a th:href="@{/v1/company/post/detail(id=${post.id}, postType=${post.postType})}"
                                            th:text="${post.title}"></a>
                                     </h6>
 
-                                    <div class="custom-block-bottom d-flex mt-1">
+                                    <div class="custom-block-bottom d-flex flex-wrap mt-1">
                                         <div class="col-auto d-flex m-2"><span>게시날짜:<span
                                                 th:text="${post.createdAt}"></span></span></div>
                                         <div class="col-auto d-flex m-2"><span>마감일:<span
@@ -152,9 +162,10 @@
 
                                 <!-- 버튼 부 -->
                                 <div class="d-flex flex-column ms-auto">
-                                    <button type="button" class="btn-light"
+                                    <button type="button" class="btn btn-outline-secondary"
                                             th:id="${post.id}" name="interview" onclick="applicantList(this)">
-                                        채용관리
+                                        <span class="d-none d-sm-inline">채용관리</span>
+                                        <span class="d-inline d-sm-none">📋</span>
                                     </button>
                                 </div>
                             </div>

--- a/src/main/resources/templates/fragment/company-header.html
+++ b/src/main/resources/templates/fragment/company-header.html
@@ -6,7 +6,7 @@
 
      <div class="col-lg-2 col-md-3 col-sm-2 col-3 my-3">
       <a class="navbar-brand" href="/v1">
-       <img src="/images/pod-talk-logo.png" class="logo-image img-fluid" alt="Job-a logo-image" style="width: 190px;">
+       <img src="/images/pod-talk-logo.png" class="logo-image img-fluid" alt="Job-a logo-image" style="width: 120px;">
       </a>
      </div>
 

--- a/src/main/resources/templates/user/apply-list.html
+++ b/src/main/resources/templates/user/apply-list.html
@@ -125,7 +125,7 @@
                     <!-- Thymeleaf 반복문을 사용하여 ArrayList 내의 객체들을 처리 -->
                     <div th:each="letterItem, letterItemStat : ${letter}" th:id="'postPage'+${letterItemStat.index}">
                         <div th:each="letters, lettersStat : ${letterItem}" class="col-lg-10 col-12 mb-4 mb-lg-2 mx-auto">
-                            <div class="custom-block d-flex d-md-block flex-md-row">
+                            <div class="custom-block d-flex ">
                                 <div class="custom-block-info">
                                     <!-- th:with를 사용하여 현재 letter의 postId를 변수에 저장 -->
                                     <div th:with="currentPostId=${letters.postId}">
@@ -137,16 +137,18 @@
                                                         <i class="bi-clock-fill custom-icon" th:title="'지원일자 : ' + ${letters.submitDate.substring(0, 10)}"></i>
                                                         <span th:text="'지원일자 : ' + ${letters.submitDate}"></span>
                                                     </small>
-                                                    <small>
-                                                        <span th:if="${letters.postType eq 'MZ'}" class="badge bg-primary me-1">MZ 공고</span>
-                                                        <span th:if="${letters.postType eq 'NORMAL'}" class="badge bg-secondary me-1">일반 공고</span>
-                                                    </small>
-                                                    <small>
-                                                        <span th:if="${letters.applicationStatus eq 'IN_PROGRESS'}" class="badge bg-warning ms-1 me-1">진행중</span>
-                                                        <span th:if="${letters.applicationStatus eq 'PASS'}" class="badge bg-success ms-1 me-1">합격</span>
-                                                        <span th:if="${letters.applicationStatus eq 'FAIL'}" class="badge bg-secondary ms-1 me-1">불합격</span>
-                                                    </small>
-                                                    <small><span class="badge bg-dark ms-1" th:text="${letters.job}" th:if="${letters.postType eq 'NORMAL'}"></span></small>
+                                                    <div class="badge-wrap">
+                                                        <small>
+                                                            <span th:if="${letters.postType eq 'MZ'}" class="badge bg-primary mx-1">MZ 공고</span>
+                                                            <span th:if="${letters.postType eq 'NORMAL'}" class="badge bg-secondary mx-1">일반 공고</span>
+                                                        </small>
+                                                        <small>
+                                                            <span th:if="${letters.applicationStatus eq 'IN_PROGRESS'}" class="badge bg-warning mx-1">진행중</span>
+                                                            <span th:if="${letters.applicationStatus eq 'PASS'}" class="badge bg-success mx-1">합격</span>
+                                                            <span th:if="${letters.applicationStatus eq 'FAIL'}" class="badge bg-secondary mx-1">불합격</span>
+                                                        </small>
+                                                        <small><span class="badge bg-dark mx-1" th:text="${letters.job}" th:if="${letters.postType eq 'NORMAL'}"></span></small>
+                                                    </div>
                                                 </div>
 
                                                 <h5 class="m-2 text-dark" th:text="${companyInfo.title}+' - '+${companyInfo.companyName}"></h5>
@@ -175,7 +177,10 @@
 
                                 <!-- 버튼 부 -->
                                 <div class="d-flex flex-column ms-auto">
-                                    <button type="button" class="btn btn-outline-secondary" th:id="${letters.applicationLetterId}" name="delete">지원취소</button>
+                                    <button type="button" class="btn btn-outline-secondary" th:id="${letters.applicationLetterId}" name="delete">
+                                        <span class="d-none d-sm-inline">지원취소</span>
+                                        <span class="d-inline d-sm-done"></span>
+                                    </button>
                                     <button type="button" class="btn btn-outline-secondary mt-2" data-bs-toggle="modal" data-bs-target="#myModal" >진행상태 변경</button>
                                 </div>
                             </div>


### PR DESCRIPTION
### 헤더
- 로고 사이즈 조정 (190->120px)

## 공고관리
### 공고목록
- 목록 칸의 여백 조정
- 모바일 페이지 호환
- 정렬버튼의 엑티브 상태값 반영

### 일반/MZ 입력 폼
- 가운데 정렬
- input 레이아웃 조정

### 상세보기
- 목록으로 돌아가기 버튼 구현
- 정렬

### FAQ
- 입력 그룹 위쪽으로 배치
- 10개제한 안내문 변경
- 등록 버튼 재배치
- 스크립트로 10개 이상 등록 방지적용

### 기업페이지(정보)
- 사진 margin 값 추가
- 수정 폼 버튼 디자인 변경
